### PR TITLE
Harden nflverse data fetching and error handling

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
+import { respondWithError } from "@/lib/api";
 
 export const runtime = "nodejs";
 export const revalidate = 0;
 
 export async function GET() {
-  return NextResponse.json({ status: "ok", timestamp: new Date().toISOString(), uptime: process.uptime() });
+  try {
+    return NextResponse.json({ status: "ok", timestamp: new Date().toISOString(), uptime: process.uptime() });
+  } catch (error) {
+    return respondWithError("GET /api/health", error, { input: {} });
+  }
 }
 

--- a/app/api/prewarm/route.ts
+++ b/app/api/prewarm/route.ts
@@ -1,6 +1,6 @@
 
 import { NextResponse } from "next/server";
-import { fetchWithRetry } from "@/lib/http";
+import { fetchText } from "@/lib/http";
 import {
   HttpError,
   parseBooleanParam,
@@ -27,7 +27,6 @@ const PREWARM_MAX_REQUESTS = parsePositiveInt(process.env.PREWARM_MAX_REQUESTS, 
 const PREWARM_CONCURRENCY = parsePositiveInt(process.env.PREWARM_CONCURRENCY, 4);
 const PREWARM_ATTEMPTS = parsePositiveInt(process.env.PREWARM_ATTEMPTS, 2);
 const PREWARM_TIMEOUT_MS = parsePositiveMs(process.env.PREWARM_TIMEOUT_MS ?? process.env.FETCH_TIMEOUT_MS, 15000);
-const PREWARM_RETRY_DELAY_MS = parsePositiveMs(process.env.PREWARM_RETRY_DELAY_MS ?? process.env.FETCH_RETRY_DELAY_MS, 750);
 
 type PrewarmResult = {
   url: string;
@@ -36,10 +35,14 @@ type PrewarmResult = {
   attempts: number;
   durationMs: number;
   error?: string;
+  urlHints?: string[];
 };
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
+  const input: Record<string, unknown> = {
+    query: Object.fromEntries(url.searchParams.entries()),
+  };
   try {
     const season = parseIntegerParam(url, "season", 2025, { min: 1900, max: 2100 });
     const startWeek = parseIntegerParam(url, "startWeek", 1, { min: 1, max: 30 });
@@ -85,6 +88,17 @@ export async function GET(req: Request) {
     const results: PrewarmResult[] = new Array(reqs.length);
     let cursor = 0;
     const workerCount = Math.max(1, Math.min(PREWARM_CONCURRENCY, reqs.length));
+    const maxRetries = Math.max(0, PREWARM_ATTEMPTS - 1);
+
+    const parseResponse = (text: string, href: string) => {
+      if (!text) return null;
+      try {
+        return JSON.parse(text);
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        throw new Error(`Invalid JSON from ${href}: ${err.message}`);
+      }
+    };
 
     const worker = async () => {
       while (true) {
@@ -95,37 +109,77 @@ export async function GET(req: Request) {
         const started = Date.now();
         let retries = 0;
         try {
-          const response = await fetchWithRetry(
+          const text = await fetchText(
             href,
             { cache: "no-store" },
             {
-              attempts: PREWARM_ATTEMPTS,
               timeoutMs: PREWARM_TIMEOUT_MS,
-              retryDelayMs: PREWARM_RETRY_DELAY_MS,
-              onAttemptFailure: () => { retries += 1; },
+              retries: maxRetries,
+              onRetry: () => { retries += 1; },
             },
           );
-          results[currentIndex] = {
-            url: href,
-            ok: true,
-            status: response.status,
-            attempts: retries + 1,
-            durationMs: Date.now() - started,
-          };
-        } catch (error) {
-          const err = error instanceof Error ? error : new Error(String(error));
+          const payload = parseResponse(text, href);
+          const durationMs = Date.now() - started;
+          if (payload && typeof payload === "object" && "error" in payload && (payload as { error?: unknown }).error) {
+            const message = typeof (payload as { error?: unknown }).error === "string"
+              ? String((payload as { error?: unknown }).error)
+              : JSON.stringify((payload as { error?: unknown }).error);
+            const hints = Array.isArray((payload as { urlHints?: unknown }).urlHints)
+              ? (payload as { urlHints?: unknown }).urlHints!.map((hint: unknown) => String(hint))
+              : undefined;
+            results[currentIndex] = {
+              url: href,
+              ok: false,
+              status: 200,
+              attempts: retries + 1,
+              durationMs,
+              error: message,
+              urlHints: hints,
+            };
+          } else {
+            results[currentIndex] = {
+              url: href,
+              ok: true,
+              status: 200,
+              attempts: retries + 1,
+              durationMs,
+            };
+          }
+        } catch (caught) {
+          const durationMs = Date.now() - started;
+          const err = caught instanceof Error ? caught : new Error(String(caught));
           const status = err instanceof HttpError
             ? err.status
             : typeof (err as any)?.status === "number"
               ? Number((err as any).status)
               : undefined;
+          let urlHints: string[] | undefined;
+          if (err instanceof HttpError) {
+            const detail = err.detail;
+            if (detail) {
+              try {
+                const parsed = JSON.parse(detail);
+                if (Array.isArray(parsed?.urlHints)) {
+                  urlHints = parsed.urlHints.map((hint: unknown) => String(hint));
+                } else if (parsed && typeof parsed === "object" && typeof parsed.url === "string") {
+                  urlHints = [parsed.url];
+                }
+              } catch {
+                // ignore parse errors on detail snapshot
+              }
+            }
+            if (!urlHints && Array.isArray(err.urlHints)) {
+              urlHints = err.urlHints.map((hint) => String(hint));
+            }
+          }
           results[currentIndex] = {
             url: href,
             ok: false,
             status,
             attempts: retries + 1,
-            durationMs: Date.now() - started,
+            durationMs,
             error: err.message,
+            urlHints,
           };
         }
       }
@@ -134,13 +188,22 @@ export async function GET(req: Request) {
     await Promise.all(Array.from({ length: workerCount }, () => worker()));
     const warmed = results.filter((entry) => entry.ok).length;
     const failed = results.length - warmed;
+    const errors = results
+      .filter((entry) => !entry.ok)
+      .map((entry) => {
+        const statusPart = entry.status ? ` [${entry.status}]` : "";
+        const hintPart = entry.urlHints?.length ? ` (hints: ${entry.urlHints.join(", ")})` : "";
+        const message = entry.error ?? "Request failed";
+        return `${entry.url}${statusPart}: ${message}${hintPart}`;
+      });
     return NextResponse.json({
       requested: reqs.length,
       warmed,
       failed,
+      errors,
       results,
     });
   } catch (error) {
-    return respondWithError("GET /api/prewarm", error);
+    return respondWithError("GET /api/prewarm", error, { input });
   }
 }

--- a/app/api/standings/route.ts
+++ b/app/api/standings/route.ts
@@ -7,11 +7,12 @@ export const runtime = "nodejs";
 export const revalidate = 0;
 
 export async function GET() {
+  const input: Record<string, unknown> = {};
   try {
     const records = await loadRecords();
     const standings = computeStandings(records);
     return NextResponse.json({ recordsCount: records.length, standings });
   } catch (error) {
-    return respondWithError("GET /api/standings", error);
+    return respondWithError("GET /api/standings", error, { input });
   }
 }

--- a/app/matchups/page.tsx
+++ b/app/matchups/page.tsx
@@ -26,6 +26,12 @@ export default function MatchupsPage() {
       setLoading(true); setError(null);
       const q = new URLSearchParams({ season, week, format, mode, includeK: String(includeK), defense, home, away, record: String(record) }).toString();
       const response = await fetchJson<MatchResp>(`/api/matchup?${q}`);
+      if (response && typeof response === "object" && "error" in response) {
+        const message = typeof (response as { error?: unknown }).error === "string"
+          ? String((response as { error?: unknown }).error)
+          : "Unable to simulate matchup";
+        throw new Error(message);
+      }
       setData(response);
     } catch (e) {
       console.error("Failed to simulate matchup", e);

--- a/app/rankings/page.tsx
+++ b/app/rankings/page.tsx
@@ -15,6 +15,12 @@ export default function RankingsPage() {
     try {
       const q = new URLSearchParams({ season, week, format, mode, includeK: String(true), defense: "none" }).toString();
       const response = await fetchJson<Api>(`/api/scores?${q}`);
+      if (response && typeof response === "object" && "error" in response) {
+        const message = typeof (response as { error?: unknown }).error === "string"
+          ? String((response as { error?: unknown }).error)
+          : "Unable to load rankings";
+        throw new Error(message);
+      }
       setData(response);
     } catch (e) {
       console.error("Failed to load rankings", e);

--- a/app/schools/[school]/page.tsx
+++ b/app/schools/[school]/page.tsx
@@ -20,6 +20,12 @@ export default function SchoolDetail({ params }: { params: { school: string } })
     setError(null);
     try {
       const response = await fetchJson<Api>(`/api/school/${encodeURIComponent(school)}?${q}`);
+      if (response && typeof response === "object" && "error" in response) {
+        const message = typeof (response as { error?: unknown }).error === "string"
+          ? String((response as { error?: unknown }).error)
+          : `Unable to load data for ${school}`;
+        throw new Error(message);
+      }
       setData(response);
     } catch (e) {
       console.error(`Failed to load school detail for ${school}`, e);

--- a/app/schools/page.tsx
+++ b/app/schools/page.tsx
@@ -14,6 +14,12 @@ export default function SchoolsPage() {
       setError(null);
       try {
         const response = await fetchJson<Api>(`/api/scores?season=2025&week=1&format=ppr&mode=weekly&includeK=true&defense=none`);
+        if (response && typeof response === "object" && "error" in response) {
+          const message = typeof (response as { error?: unknown }).error === "string"
+            ? String((response as { error?: unknown }).error)
+            : "Unable to load school list";
+          throw new Error(message);
+        }
         if (!cancelled) {
           setData(response);
         }

--- a/app/standings/page.tsx
+++ b/app/standings/page.tsx
@@ -13,6 +13,12 @@ export default function StandingsPage() {
       setError(null);
       try {
         const response = await fetchJson<Api>("/api/standings");
+        if (response && typeof response === "object" && "error" in response) {
+          const message = typeof (response as { error?: unknown }).error === "string"
+            ? String((response as { error?: unknown }).error)
+            : "Unable to load standings";
+          throw new Error(message);
+        }
         if (!cancelled) setData(response);
       } catch (e) {
         console.error("Failed to load standings", e);

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,113 +1,312 @@
+import http from "node:http";
+import https from "node:https";
+import type { IncomingHttpHeaders, OutgoingHttpHeaders } from "node:http";
+import type { RequestOptions as HttpsRequestOptions } from "node:https";
+import { HttpsProxyAgent } from "next/dist/compiled/https-proxy-agent";
 import { HttpError } from "./api";
+
+const PROXY_ENV_ORDER = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] as const;
+
+const getProxyUrl = (): string | undefined => {
+  for (const key of PROXY_ENV_ORDER) {
+    const value = process.env[key];
+    if (value && value.trim()) return value.trim();
+  }
+  return undefined;
+};
+
+const parseNoProxyList = (): string[] => {
+  const value = process.env.NO_PROXY || process.env.no_proxy;
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+const NO_PROXY = parseNoProxyList();
+const PROXY_URL = getProxyUrl();
+let HTTPS_PROXY_AGENT: InstanceType<typeof HttpsProxyAgent> | undefined;
+
+const getDefaultPort = (protocol: string): string | undefined => {
+  if (protocol === "https:") return "443";
+  if (protocol === "http:") return "80";
+  return undefined;
+};
+
+const shouldBypassProxy = (url: string): boolean => {
+  if (!NO_PROXY.length) return false;
+  let host: string | undefined;
+  let port: string | undefined;
+  try {
+    const parsed = new URL(url);
+    host = parsed.hostname;
+    port = parsed.port || getDefaultPort(parsed.protocol);
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  for (const pattern of NO_PROXY) {
+    if (pattern === "*") return true;
+    let candidate = pattern;
+    let patternPort: string | undefined;
+    const colonIndex = pattern.lastIndexOf(":");
+    if (colonIndex > 0 && colonIndex < pattern.length - 1) {
+      const possiblePort = pattern.slice(colonIndex + 1);
+      if (/^\d+$/.test(possiblePort)) {
+        patternPort = possiblePort;
+        candidate = pattern.slice(0, colonIndex);
+      }
+    }
+    if (patternPort && port && patternPort !== port) continue;
+    if (!candidate) continue;
+    if (candidate.startsWith(".")) {
+      const suffix = candidate.slice(1);
+      if (host === suffix || host.endsWith(`.${suffix}`)) return true;
+    } else if (host === candidate || host.endsWith(`.${candidate}`)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const ensureProxyAgent = () => {
+  if (!PROXY_URL) return undefined;
+  if (!HTTPS_PROXY_AGENT) {
+    try {
+      HTTPS_PROXY_AGENT = new HttpsProxyAgent(PROXY_URL);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("[http] Failed to configure proxy agent", error);
+      HTTPS_PROXY_AGENT = undefined;
+    }
+  }
+  return HTTPS_PROXY_AGENT;
+};
+
+const shouldUseProxy = (url: string): boolean => Boolean(PROXY_URL) && !shouldBypassProxy(url);
+
+const toNodeHeaders = (headers?: HeadersInit): OutgoingHttpHeaders => {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    const out: OutgoingHttpHeaders = {};
+    headers.forEach((value, key) => {
+      out[key] = value;
+    });
+    return out;
+  }
+  if (Array.isArray(headers)) {
+    return headers.reduce<OutgoingHttpHeaders>((acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    }, {});
+  }
+  return { ...headers };
+};
+
+const toHeadersInit = (headers: IncomingHttpHeaders): HeadersInit => {
+  const entries: [string, string][] = [];
+  for (const [key, value] of Object.entries(headers)) {
+    if (!value || !key) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (v !== undefined) entries.push([key, v]);
+      }
+    } else {
+      entries.push([key, value]);
+    }
+  }
+  return entries;
+};
+
+const proxyFetch = (url: string, init: RequestInit): Promise<Response> => {
+  const parsed = new URL(url);
+  const isHttps = parsed.protocol === "https:";
+  const headers = toNodeHeaders(init.headers);
+  const requestOptions: HttpsRequestOptions = {
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    port: parsed.port || undefined,
+    path: `${parsed.pathname}${parsed.search}`,
+    method: init.method ?? "GET",
+    headers,
+  };
+  if (isHttps && shouldUseProxy(url)) {
+    const agent = ensureProxyAgent();
+    if (agent) {
+      requestOptions.agent = agent;
+    }
+  }
+  return new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    const requestFn = isHttps ? https.request : http.request;
+    const req = requestFn(requestOptions, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => {
+        if (chunk) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      res.on("error", (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      });
+      res.on("end", () => {
+        if (settled) return;
+        settled = true;
+        const body = Buffer.concat(chunks);
+        const response = new Response(body, {
+          status: res.statusCode ?? 0,
+          statusText: res.statusMessage ?? "",
+          headers: toHeadersInit(res.headers),
+        });
+        resolve(response);
+      });
+    });
+
+    req.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
+
+    const { signal } = init;
+    if (signal) {
+      if (signal.aborted) {
+        const abortError = new Error("Request aborted");
+        abortError.name = "AbortError";
+        req.destroy(abortError);
+        return;
+      }
+      const onAbort = () => {
+        if (settled) return;
+        settled = true;
+        const abortError = new Error("Request aborted");
+        abortError.name = "AbortError";
+        req.destroy(abortError);
+        reject(abortError);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      req.on("close", () => {
+        signal.removeEventListener("abort", onAbort);
+      });
+    }
+
+    if (init.body) {
+      if (typeof init.body === "string" || Buffer.isBuffer(init.body)) {
+        req.write(init.body);
+      } else if (init.body instanceof URLSearchParams) {
+        req.write(init.body.toString());
+      } else {
+        req.write(String(init.body));
+      }
+    }
+
+    req.end();
+  });
+};
+
+type RetryInfo = {
+  attempt: number;
+  url: string;
+  error: Error;
+};
+
+type FetchOptions = {
+  timeoutMs?: number;
+  retries?: number;
+  onRetry?: (info: RetryInfo) => void;
+};
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-const parsePositiveInt = (value: string | undefined, fallback: number): number => {
-  const num = Number(value);
-  return Number.isFinite(num) && num > 0 ? Math.trunc(num) : fallback;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_RETRIES = 2;
+const BASE_BACKOFF_MS = 300;
+
+const sanitizeSnippet = (value: string): string => {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  return collapsed.length > 200 ? `${collapsed.slice(0, 200)}…` : collapsed;
 };
 
-const parsePositiveMs = (value: string | undefined, fallback: number): number => {
-  const num = Number(value);
-  return Number.isFinite(num) && num > 0 ? num : fallback;
-};
-
-const DEFAULT_ATTEMPTS = parsePositiveInt(process.env.FETCH_ATTEMPTS, 3);
-const DEFAULT_TIMEOUT_MS = parsePositiveMs(process.env.FETCH_TIMEOUT_MS, 15000);
-const DEFAULT_RETRY_DELAY_MS = parsePositiveMs(process.env.FETCH_RETRY_DELAY_MS, 750);
-
-export interface RetryInfo {
-  attempt: number;
-  error: Error;
-  url: string;
-}
-
-export interface RetryOptions {
-  attempts?: number;
-  timeoutMs?: number;
-  retryDelayMs?: number;
-  onAttemptFailure?: (info: RetryInfo) => void;
-}
-
-const shouldRetryStatus = (status?: number) => {
+const shouldRetryStatus = (status?: number): boolean => {
   if (status === undefined) return true;
-  return status >= 500 || status === 408 || status === 429;
+  if (status >= 500) return true;
+  return status === 408 || status === 429;
 };
 
-const normalizeError = (error: unknown, url: string, timeoutMs: number): Error => {
+const toHttpError = (url: string, error: unknown, fallbackStatus = 500): HttpError => {
   if (error instanceof HttpError) return error;
-  if (error instanceof Error) {
-    if (error.name === "AbortError") {
-      return new Error(`Request to ${url} timed out after ${timeoutMs}ms`, { cause: error });
-    }
-    return error;
-  }
-  return new Error(String(error));
+  const err = error instanceof Error ? error : new Error(String(error));
+  const status = typeof (err as any)?.status === "number" ? Number((err as any).status) : fallbackStatus;
+  return new HttpError(status, `Request to ${url} failed: ${err.message}`, { cause: err });
 };
 
-const toHttpError = (error: Error, url: string): HttpError => {
-  if (error instanceof HttpError) return error;
-  const status = typeof (error as any)?.status === "number" ? Number((error as any).status) : undefined;
-  const message = error.message || `Request to ${url} failed`;
-  return new HttpError(status ?? 500, message, { cause: error });
-};
-
-export async function fetchWithRetry(
+const performRequest = async (
   url: string,
   init: RequestInit = {},
-  options: RetryOptions = {},
-): Promise<Response> {
-  const attempts = Math.max(1, options.attempts ?? DEFAULT_ATTEMPTS);
+  options: FetchOptions = {},
+): Promise<Response> => {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
-  let lastError: Error | undefined;
+  const retries = Math.max(0, options.retries ?? DEFAULT_RETRIES);
 
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const response = await fetch(url, { ...init, signal: controller.signal });
-      if (!response.ok) {
-        const error = new HttpError(
-          response.status,
-          `Request to ${url} failed with status ${response.status} ${response.statusText || ""}`.trim(),
-        );
-        if (attempt >= attempts || !shouldRetryStatus(response.status)) {
-          throw error;
-        }
-        lastError = error;
-        options.onAttemptFailure?.({ attempt, error, url });
-        const retryAfterHeader = response.headers.get("retry-after");
-        const retryAfterSeconds = retryAfterHeader ? Number(retryAfterHeader) : NaN;
-        const delay = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
-          ? retryAfterSeconds * 1000
-          : retryDelayMs * attempt;
+      const requestInit: RequestInit = { ...(init ?? {}), signal: controller.signal };
+      const response = await (shouldUseProxy(url) ? proxyFetch(url, requestInit) : fetch(url, requestInit));
+      if (response.ok) {
+        return response;
+      }
+      const snippet = await response.text().then(sanitizeSnippet).catch(() => "");
+      const message = `Request to ${url} failed with status ${response.status} ${response.statusText || ""}`.trim();
+      const errorBody = snippet ? `Body: ${snippet}` : "Body: <empty>";
+      const error = new HttpError(response.status, `${message}. ${errorBody}`);
+      error.detail = snippet;
+      if (attempt < retries && shouldRetryStatus(response.status)) {
+        options.onRetry?.({ attempt: attempt + 1, url, error });
+        const delay = BASE_BACKOFF_MS * (2 ** attempt);
         await sleep(delay);
         continue;
       }
-      return response;
+      throw error;
     } catch (caught) {
-      let error = normalizeError(caught, url, timeoutMs);
-      if (!(error instanceof HttpError) && typeof (error as any)?.status === "number") {
-        error = toHttpError(error, url);
+      const err = caught instanceof Error ? caught : new Error(String(caught));
+      const isAbort = err.name === "AbortError";
+      const status = typeof (err as any)?.status === "number" ? Number((err as any).status) : undefined;
+      if (attempt < retries && (isAbort || shouldRetryStatus(status))) {
+        options.onRetry?.({ attempt: attempt + 1, url, error: err });
+        const delay = BASE_BACKOFF_MS * (2 ** attempt);
+        await sleep(delay);
+        continue;
       }
-      lastError = error;
-      const status = error instanceof HttpError ? error.status : undefined;
-      if (attempt >= attempts || (status !== undefined && !shouldRetryStatus(status))) {
-        throw error;
+      if (isAbort) {
+        throw new HttpError(504, `Request to ${url} timed out after ${timeoutMs}ms`, { cause: err });
       }
-      options.onAttemptFailure?.({ attempt, error, url });
-      await sleep(retryDelayMs * attempt);
+      throw toHttpError(url, err, status ?? 500);
     } finally {
       clearTimeout(timeout);
     }
   }
 
-  if (lastError) {
-    const error = lastError instanceof HttpError ? lastError : toHttpError(lastError, url);
-    throw new HttpError(error.status ?? 500, `Failed to fetch ${url} after ${attempts} attempts`, { cause: error });
-  }
+  throw new HttpError(500, `Request to ${url} failed after ${retries + 1} attempts`);
+};
 
-  throw new HttpError(500, `Failed to fetch ${url} after ${attempts} attempts`);
+export async function fetchText(
+  url: string,
+  init?: RequestInit,
+  options?: FetchOptions,
+): Promise<string> {
+  const response = await performRequest(url, init, options);
+  return response.text();
 }
 
+export async function fetchBuffer(
+  url: string,
+  init?: RequestInit,
+  options?: FetchOptions,
+): Promise<Buffer> {
+  const response = await performRequest(url, init, options);
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}

--- a/lib/nflverse.ts
+++ b/lib/nflverse.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from "fs";
 import path from "path";
+import { gunzipSync } from "zlib";
 import { HttpError } from "./api";
-import { fetchWithRetry } from "./http";
+import { fetchBuffer } from "./http";
 import { normalize } from "./utils";
 import type { Leader } from "./types";
 
@@ -9,11 +10,19 @@ const RELEASE_BASE = "https://github.com/nflverse/nflverse-data/releases/downloa
 const DEFAULT_USER_AGENT = "college-alumni-fantasy/1.0 (+https://github.com/)";
 const CACHE_SECONDS = Number(process.env.CACHE_SECONDS ?? 3600);
 const CACHE_MS = CACHE_SECONDS > 0 ? CACHE_SECONDS * 1000 : 0;
-const CACHE_ROOT = process.env.NFLVERSE_CACHE_DIR ? path.resolve(process.env.NFLVERSE_CACHE_DIR) : path.join(process.cwd(), ".next", "cache", "nflverse");
+const CACHE_ROOT = process.env.NFLVERSE_CACHE_DIR
+  ? path.resolve(process.env.NFLVERSE_CACHE_DIR)
+  : path.join(process.cwd(), ".next", "cache", "nflverse");
 const HEADERS: Record<string, string> = {
   "User-Agent": process.env.NFLVERSE_USER_AGENT || DEFAULT_USER_AGENT,
-  Accept: "text/csv,application/octet-stream",
+  Accept: "text/csv,application/octet-stream,application/gzip",
 };
+
+export const urlPlayerStats = (season: number) =>
+  `${RELEASE_BASE}/stats_player/stats_player_week_${season}.csv.gz`;
+
+export const urlWeeklyRosters = (season: number) =>
+  `${RELEASE_BASE}/weekly_rosters/roster_week_${season}.csv.gz`;
 
 const toPositiveInt = (value: string | undefined, fallback: number): number => {
   const num = Number(value);
@@ -26,8 +35,11 @@ const toPositiveMs = (value: string | undefined, fallback: number): number => {
 };
 
 const NFLVERSE_FETCH_ATTEMPTS = toPositiveInt(process.env.NFLVERSE_FETCH_ATTEMPTS ?? process.env.FETCH_ATTEMPTS, 3);
-const NFLVERSE_FETCH_TIMEOUT_MS = toPositiveMs(process.env.NFLVERSE_FETCH_TIMEOUT_MS ?? process.env.FETCH_TIMEOUT_MS, 20000);
-const NFLVERSE_FETCH_RETRY_DELAY_MS = toPositiveMs(process.env.NFLVERSE_FETCH_RETRY_DELAY_MS ?? process.env.FETCH_RETRY_DELAY_MS, 750);
+const NFLVERSE_FETCH_TIMEOUT_MS = toPositiveMs(
+  process.env.NFLVERSE_FETCH_TIMEOUT_MS ?? process.env.FETCH_TIMEOUT_MS,
+  20000,
+);
+const NFLVERSE_FETCH_RETRIES = Math.max(0, NFLVERSE_FETCH_ATTEMPTS - 1);
 
 type CsvRow = Record<string, string>;
 
@@ -78,6 +90,49 @@ const parseCsv = (text: string): CsvRow[] => {
     result.push(obj);
   }
   return result;
+};
+
+export class NflverseAssetMissingError extends HttpError {
+  url: string;
+
+  releaseTag: string;
+
+  season: number;
+
+  week?: number;
+
+  urlHints: string[];
+
+  code = "NFLVERSE_ASSET_MISSING" as const;
+
+  constructor(params: { url: string; releaseTag: string; season: number; week?: number }) {
+    super(404, "NFLVERSE_ASSET_MISSING", {
+      detail: `NFLverse asset not yet available at ${params.url}`,
+    });
+    this.url = params.url;
+    this.releaseTag = params.releaseTag;
+    this.season = params.season;
+    this.week = params.week;
+    this.urlHints = [params.url];
+  }
+}
+
+const logCsvSnapshot = (csv: string, context: string) => {
+  const lines = csv.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const headers = lines[0] ?? "";
+  const firstRow = lines[1] ?? "";
+  // eslint-disable-next-line no-console
+  console.error(`[nflverse] CSV parse issue for ${context}`, { headers, firstRow });
+};
+
+const parseCsvSafe = (csv: string, context: string): CsvRow[] => {
+  try {
+    return parseCsv(csv);
+  } catch (error) {
+    logCsvSnapshot(csv, context);
+    const err = error instanceof Error ? error : new Error(String(error));
+    throw new Error(`[nflverse] Failed to parse CSV for ${context}: ${err.message}`, { cause: err });
+  }
 };
 
 type MapCollections = {
@@ -174,50 +229,154 @@ const rosterLookupCache = new Map<number, RosterLookup>();
 const playerStatsSeasonCache = new Map<number, Map<number, NflversePlayerStat[]>>();
 const snapSeasonCache = new Map<number, Map<number, DefSnapRow[]>>();
 const teamDefenseSeasonCache = new Map<number, Map<number, TeamDefenseInput[]>>();
+const fallbackNameTeamWarnings = new Set<string>();
+const playerColumnWarnings = new Set<number>();
 
-const ensureCacheDir = async () => { await fs.mkdir(CACHE_ROOT, { recursive: true }); };
+const getCachePath = (releaseTag: string, filename: string) => path.join(CACHE_ROOT, releaseTag, filename);
 
-const readCache = async (key: string): Promise<string | null> => {
-  const file = path.join(CACHE_ROOT, `${key}.csv`);
+const readCachedBuffer = async (releaseTag: string, filename: string): Promise<Buffer | null> => {
+  const file = getCachePath(releaseTag, filename);
   try {
     const stat = await fs.stat(file);
     if (CACHE_MS > 0 && Date.now() - stat.mtimeMs > CACHE_MS) return null;
-    return await fs.readFile(file, "utf-8");
-  } catch { return null; }
-};
-
-const writeCache = async (key: string, contents: string) => {
-  const file = path.join(CACHE_ROOT, `${key}.csv`);
-  await ensureCacheDir();
-  await fs.writeFile(file, contents, "utf-8");
-};
-
-async function fetchCsv(key: string, url: string): Promise<CsvRow[]> {
-  const cached = await readCache(key);
-  if (cached) return parseCsv(cached);
-  try {
-    const response = await fetchWithRetry(
-      url,
-      { headers: HEADERS, cache: "no-store" },
-      {
-        attempts: NFLVERSE_FETCH_ATTEMPTS,
-        timeoutMs: NFLVERSE_FETCH_TIMEOUT_MS,
-        retryDelayMs: NFLVERSE_FETCH_RETRY_DELAY_MS,
-      },
-    );
-    const text = await response.text();
-    await writeCache(key, text);
-    return parseCsv(text);
-  } catch (error) {
-    if (error instanceof HttpError) {
-      throw new HttpError(error.status, `[nflverse] ${error.message}`, { cause: error });
-    }
-    if (error instanceof Error) {
-      throw new Error(`[nflverse] ${error.message}`, { cause: error });
-    }
-    throw new Error(`[nflverse] ${String(error)}`);
+    return await fs.readFile(file);
+  } catch {
+    return null;
   }
+};
+
+const writeCachedBuffer = async (releaseTag: string, filename: string, contents: Buffer) => {
+  const file = getCachePath(releaseTag, filename);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, contents);
+};
+
+type CsvAssetOptions = {
+  releaseTag: string;
+  filename: string;
+  url: string;
+  season: number;
+  week?: number;
+  gz?: boolean;
+  requireHead?: boolean;
+};
+
+const HEAD_RETRIES = Math.min(1, NFLVERSE_FETCH_RETRIES);
+
+async function fetchCsvAsset(options: CsvAssetOptions): Promise<CsvRow[]> {
+  const { releaseTag, filename, url, season, week, gz = false, requireHead = true } = options;
+  let raw = await readCachedBuffer(releaseTag, filename);
+  if (!raw) {
+    if (requireHead) {
+      try {
+        await fetchBuffer(
+          url,
+          { method: "HEAD", headers: HEADERS, cache: "no-store" },
+          { timeoutMs: NFLVERSE_FETCH_TIMEOUT_MS, retries: HEAD_RETRIES },
+        );
+      } catch (error) {
+        if (error instanceof HttpError && error.status === 404) {
+          // eslint-disable-next-line no-console
+          console.warn("NFLVERSE_MISS", { releaseTag, url, season, week });
+          throw new NflverseAssetMissingError({ url, releaseTag, season, week });
+        }
+        if (error instanceof HttpError) {
+          throw new HttpError(error.status, `[nflverse] ${error.message}`, { cause: error });
+        }
+        const err = error instanceof Error ? error : new Error(String(error));
+        throw new Error(`[nflverse] HEAD ${url} failed: ${err.message}`, { cause: err });
+      }
+    }
+    try {
+      raw = await fetchBuffer(
+        url,
+        { headers: HEADERS, cache: "no-store" },
+        { timeoutMs: NFLVERSE_FETCH_TIMEOUT_MS, retries: NFLVERSE_FETCH_RETRIES },
+      );
+    } catch (error) {
+      if (error instanceof HttpError) {
+        throw new HttpError(error.status, `[nflverse] ${error.message}`, { cause: error });
+      }
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw new Error(`[nflverse] Failed to fetch ${url}: ${err.message}`, { cause: err });
+    }
+    await writeCachedBuffer(releaseTag, filename, raw);
+  }
+  const source = raw;
+  let text: string;
+  if (gz) {
+    try {
+      text = gunzipSync(source).toString("utf-8");
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      // eslint-disable-next-line no-console
+      console.error(`[nflverse] Failed to unzip ${releaseTag}/${filename}`, err);
+      throw new Error(`[nflverse] Failed to unzip ${releaseTag}/${filename}: ${err.message}`, { cause: err });
+    }
+  } else {
+    text = source.toString("utf-8");
+  }
+  return parseCsvSafe(text, `${releaseTag}/${filename}`);
 }
+
+const PLAYER_COLUMN_GROUPS: { field: string; aliases: string[] }[] = [
+  { field: "passing_yards", aliases: ["passing_yards", "pass_yards", "pass_yds"] },
+  { field: "passing_tds", aliases: ["passing_tds", "pass_tds", "pass_td"] },
+  { field: "interceptions", aliases: ["interceptions", "int", "ints", "pass_interceptions"] },
+  { field: "rushing_yards", aliases: ["rushing_yards", "rush_yards", "rush_yds"] },
+  { field: "rushing_tds", aliases: ["rushing_tds", "rush_tds", "rush_td"] },
+  { field: "receptions", aliases: ["receptions", "receiving_receptions", "rec", "rec_receptions"] },
+  { field: "receiving_yards", aliases: ["receiving_yards", "rec_yards", "rec_yds"] },
+  { field: "receiving_tds", aliases: ["receiving_tds", "rec_tds", "rec_td"] },
+  {
+    field: "fumbles_lost",
+    aliases: [
+      "fumbles_lost",
+      "fumbles_lost_total",
+      "fumbles_lost_offense",
+      "rushing_fumbles_lost",
+      "receiving_fumbles_lost",
+      "sack_fumbles_lost",
+    ],
+  },
+  { field: "field_goals_made", aliases: ["field_goals_made", "fg_made", "fg"] },
+  { field: "extra_points_made", aliases: ["extra_points_made", "xp_made", "xpt"] },
+  {
+    field: "player_id",
+    aliases: [
+      "player_id",
+      "gsis_id",
+      "gsis_it_id",
+      "gsis_player_id",
+      "nfl_id",
+      "pfr_id",
+      "pfr_player_id",
+      "esb_id",
+    ],
+  },
+  { field: "player_name", aliases: ["full_name", "player", "player_name"] },
+  { field: "team", aliases: ["team", "posteam", "team_abbr", "club_code", "team_code", "recent_team"] },
+  { field: "position", aliases: ["position", "pos", "depth_chart_position"] },
+  { field: "week", aliases: ["week", "game_week", "week_num", "week_number"] },
+  { field: "season", aliases: ["season"] },
+];
+
+const verifyPlayerStatColumns = (rows: CsvRow[], season: number) => {
+  if (!rows.length || playerColumnWarnings.has(season)) return;
+  const sample = rows[0];
+  const missing = PLAYER_COLUMN_GROUPS
+    .filter((group) => !group.aliases.some((alias) => alias in sample))
+    .map((group) => group.field);
+  if (missing.length) {
+    // eslint-disable-next-line no-console
+    console.warn("[nflverse] Missing expected stat columns", {
+      season,
+      missing,
+      headers: Object.keys(sample),
+    });
+  }
+  playerColumnWarnings.add(season);
+};
 
 const toNumber = (value: unknown): number => {
   if (value === null || value === undefined || value === "") return 0;
@@ -360,8 +519,28 @@ const matchPlayer = (lookup: RosterLookup, stat: { week: number; player_id: stri
   const name = normalize(stat.name ?? "");
   if (name) {
     const teamKey = `${name}|${(stat.team ?? "").toUpperCase()}`;
-    if (weekLookup?.byNameTeam.has(teamKey)) return weekLookup.byNameTeam.get(teamKey);
-    if (lookup.season.byNameTeam.has(teamKey)) return lookup.season.byNameTeam.get(teamKey);
+    const warnFallback = (scope: "week" | "season") => {
+      const warnKey = `${scope}|${stat.week}|${teamKey}`;
+      if (!fallbackNameTeamWarnings.has(warnKey)) {
+        fallbackNameTeamWarnings.add(warnKey);
+        // eslint-disable-next-line no-console
+        console.warn("[nflverse] Fallback roster match by name/team", {
+          scope,
+          week: stat.week,
+          name: stat.name,
+          team: stat.team,
+          player_id: stat.player_id,
+        });
+      }
+    };
+    if (weekLookup?.byNameTeam.has(teamKey)) {
+      warnFallback("week");
+      return weekLookup.byNameTeam.get(teamKey);
+    }
+    if (lookup.season.byNameTeam.has(teamKey)) {
+      warnFallback("season");
+      return lookup.season.byNameTeam.get(teamKey);
+    }
     if (weekLookup?.byName.has(name)) return weekLookup.byName.get(name);
     if (lookup.season.byName.has(name)) return lookup.season.byName.get(name);
   }
@@ -481,7 +660,13 @@ const parseTeamDefenseRow = (row: CsvRow, fallbackSeason: number): TeamDefenseIn
 
 export async function fetchPlayers(season: number): Promise<NflversePlayer[]> {
   if (playersCache.has(season)) return playersCache.get(season)!;
-  const rows = await fetchCsv(`roster_weekly_${season}`, `${RELEASE_BASE}/nflfastR-roster/roster_weekly_${season}.csv`);
+  const rows = await fetchCsvAsset({
+    releaseTag: "weekly_rosters",
+    filename: `roster_week_${season}.csv.gz`,
+    url: urlWeeklyRosters(season),
+    season,
+    gz: true,
+  });
   const parsed = rows
     .map((row) => parseRosterRow(row, season))
     .filter((p): p is NflversePlayer => Boolean(p) && (p as NflversePlayer).season === season);
@@ -492,7 +677,14 @@ export async function fetchPlayers(season: number): Promise<NflversePlayer[]> {
 
 const loadSeasonPlayerStats = async (season: number): Promise<Map<number, NflversePlayerStat[]>> => {
   if (playerStatsSeasonCache.has(season)) return playerStatsSeasonCache.get(season)!;
-  const rows = await fetchCsv(`stats_player_week_${season}`, `${RELEASE_BASE}/nflfastR-weekly/stats_player_week_${season}.csv`);
+  const rows = await fetchCsvAsset({
+    releaseTag: "stats_player",
+    filename: `stats_player_week_${season}.csv.gz`,
+    url: urlPlayerStats(season),
+    season,
+    gz: true,
+  });
+  verifyPlayerStatColumns(rows, season);
   const grouped = new Map<number, NflversePlayerStat[]>();
   for (const row of rows) {
     const parsed = parsePlayerStatRow(row, season);
@@ -511,7 +703,12 @@ export async function fetchWeeklyPlayerStats(season: number, week: number): Prom
 
 const loadSeasonSnapCounts = async (season: number): Promise<Map<number, DefSnapRow[]>> => {
   if (snapSeasonCache.has(season)) return snapSeasonCache.get(season)!;
-  const rows = await fetchCsv(`snap_counts_${season}`, `${RELEASE_BASE}/snap_counts/snap_counts_${season}.csv`);
+  const rows = await fetchCsvAsset({
+    releaseTag: "snap_counts",
+    filename: `snap_counts_${season}.csv`,
+    url: `${RELEASE_BASE}/snap_counts/snap_counts_${season}.csv`,
+    season,
+  });
   const grouped = new Map<number, DefSnapRow[]>();
   for (const row of rows) {
     const parsed = parseSnapRow(row, season);
@@ -531,7 +728,12 @@ export async function fetchDefensiveSnaps(season: number, week: number): Promise
 
 const loadSeasonTeamDefense = async (season: number): Promise<Map<number, TeamDefenseInput[]>> => {
   if (teamDefenseSeasonCache.has(season)) return teamDefenseSeasonCache.get(season)!;
-  const rows = await fetchCsv(`stats_team_week_${season}`, `${RELEASE_BASE}/nflfastR-weekly/stats_team_week_${season}.csv`);
+  const rows = await fetchCsvAsset({
+    releaseTag: "nflfastR-weekly",
+    filename: `stats_team_week_${season}.csv`,
+    url: `${RELEASE_BASE}/nflfastR-weekly/stats_team_week_${season}.csv`,
+    season,
+  });
   const grouped = new Map<number, TeamDefenseInput[]>();
   for (const row of rows) {
     const parsed = parseTeamDefenseRow(row, season);


### PR DESCRIPTION
## Summary
- add proxy-aware HTTP helpers with retries, timeouts, and gzip support for nflverse assets
- switch nflverse loaders to season-level release files with on-disk caching, roster fallbacks, and detailed parse warnings
- wrap API routes and client pages with friendly error handling and improve /api/prewarm diagnostics

## Testing
- npm run lint
- npm run smoke *(fails: Parse Error from upstream proxy when requesting nflverse GitHub assets)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3eca25188332b8ac12c2a76289e0