### PR TITLE
Fix url hints typing in prewarm route

### DIFF
--- a/app/api/prewarm/route.ts
+++ b/app/api/prewarm/route.ts
@@ -124,8 +124,9 @@ export async function GET(req: Request) {
             const message = typeof (payload as { error?: unknown }).error === "string"
               ? String((payload as { error?: unknown }).error)
               : JSON.stringify((payload as { error?: unknown }).error);
-            const hints = Array.isArray((payload as { urlHints?: unknown }).urlHints)
-              ? (payload as { urlHints?: unknown }).urlHints!.map((hint: unknown) => String(hint))
+            const urlHintsValue = (payload as { urlHints?: unknown }).urlHints;
+            const hints = Array.isArray(urlHintsValue)
+              ? urlHintsValue.map((hint: unknown) => String(hint))
               : undefined;
             results[currentIndex] = {
               url: href,


### PR DESCRIPTION
## Summary
- guard the prewarm response `urlHints` payload before mapping values so TypeScript recognizes the array

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc49cbcf4c8332b7633fac752c4471