### PR TITLE
Fix loading player stats by fetching csv data

### DIFF
--- a/lib/nflverse.ts
+++ b/lib/nflverse.ts
@@ -690,6 +690,14 @@ export async function fetchPlayers(season: number): Promise<NflversePlayer[]> {
 const loadSeasonPlayerStats = async (season: number): Promise<Map<number, NflversePlayerStat[]>> => {
   if (playerStatsSeasonCache.has(season)) return playerStatsSeasonCache.get(season)!;
 
+  const rows = await fetchCsvAsset({
+    releaseTag: "stats_player",
+    filename: `stats_player_week_${season}.csv.gz`,
+    url: urlPlayerStats(season),
+    season,
+    gz: true,
+  });
+
   verifyPlayerStatColumns(rows, season);
   const grouped = new Map<number, NflversePlayerStat[]>();
   for (const row of rows) {


### PR DESCRIPTION
## Summary
- fetch the player stats CSV in `loadSeasonPlayerStats` before parsing so the rows variable is defined

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7114631083329ee9e036f5345c1d