### PR TITLE
Handle placeholder college values from roster data

### DIFF
--- a/lib/collegeMap.ts
+++ b/lib/collegeMap.ts
@@ -3,9 +3,25 @@ import idMap from "@/data/player_colleges_by_id.json";
 import nameMap from "@/data/player_colleges.json";
 import { normalize } from "./utils";
 import type { Leader } from "./types";
+
+const sanitizeCollege = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed.length) return null;
+  const lower = trimmed.toLowerCase();
+  const condensed = lower.replace(/[\s./_-]+/g, "");
+  if (!condensed.length) return null;
+  if (condensed.startsWith("unknown")) return null;
+  if (condensed.startsWith("nocollege")) return null;
+  if (condensed === "na" || condensed === "none" || condensed === "null" || condensed === "tbd") return null;
+  if (condensed === "notavailable" || condensed === "tobedetermined") return null;
+  if (lower.startsWith("n/a") || lower.startsWith("na/")) return null;
+  return trimmed;
+};
+
 export function resolveCollege(leader: Leader): string {
-  const apiCollege = (leader as any).college;
-  if (apiCollege && typeof apiCollege === "string" && apiCollege.trim().length) return apiCollege;
+  const apiCollege = sanitizeCollege((leader as any).college);
+  if (apiCollege) return apiCollege;
   const pid = String((leader as any).player_id ?? "");
   if (pid && (idMap as Record<string,string>)[pid]) return (idMap as Record<string,string>)[pid];
   const byName = (nameMap as Record<string,string>)[normalize(leader.full_name)];


### PR DESCRIPTION
## Summary
- ignore placeholder college strings like "Unknown" or "N/A" so we can fall back to our mapping data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd69130cd88332ac6c486df2208820