### PR TITLE
Fix college resolution helper duplication

### DIFF
--- a/lib/collegeMap.ts
+++ b/lib/collegeMap.ts
@@ -740,9 +740,11 @@ for (const [alias, canonical] of RAW_OVERRIDES) {
   }
 }
 
-
-const sanitizeCollege = (value: unknown): string | null => {
-
+const sanitizeCollegeValue = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed.length) return null;
+  const lower = trimmed.toLowerCase();
   if (PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(lower))) return null;
   const simple = lower.replace(/[^a-z0-9]+/g, "");
   if (!simple.length) return null;
@@ -769,6 +771,7 @@ const canonicalizeCollegeValue = (value: unknown): string | null => {
   if (!sanitized) return null;
   return canonicalizeCollege(sanitized);
 };
+
 export function resolveCollege(leader: Leader): string {
   const apiCollege = canonicalizeCollegeValue((leader as any).college);
   if (apiCollege) return apiCollege;
@@ -787,23 +790,4 @@ export function resolveCollege(leader: Leader): string {
   }
 
   return "Unknown";
-
-  const condensed = lower.replace(/[\s./_-]+/g, "");
-  if (!condensed.length) return null;
-  if (condensed.startsWith("unknown")) return null;
-  if (condensed.startsWith("nocollege")) return null;
-  if (condensed === "na" || condensed === "none" || condensed === "null" || condensed === "tbd") return null;
-  if (condensed === "notavailable" || condensed === "tobedetermined") return null;
-  if (lower.startsWith("n/a") || lower.startsWith("na/")) return null;
-  return trimmed;
-};
-
-export function resolveCollege(leader: Leader): string {
-  const apiCollege = sanitizeCollege((leader as any).college);
-  if (apiCollege) return apiCollege;
-  const pid = String((leader as any).player_id ?? "");
-  if (pid && (idMap as Record<string,string>)[pid]) return (idMap as Record<string,string>)[pid];
-  const byName = (nameMap as Record<string,string>)[normalize(leader.full_name)];
-  return byName ?? "Unknown";
-
 }


### PR DESCRIPTION
## Summary
- ensure college sanitization checks for valid string values before canonicalizing
- remove the duplicate resolveCollege export and legacy fallback logic

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cda3ca12508332913c8c0d8d4023a0