### PR TITLE
Handle renamed nflverse player identifiers

### DIFF
--- a/lib/nflverse.ts
+++ b/lib/nflverse.ts
@@ -375,6 +375,7 @@ const PLAYER_COLUMN_GROUPS: { field: string; aliases: string[] }[] = [
     field: "player_id",
     aliases: [
       "player_id",
+      "player_gsis_id",
       "gsis_id",
       "gsis_it_id",
       "gsis_player_id",
@@ -384,7 +385,7 @@ const PLAYER_COLUMN_GROUPS: { field: string; aliases: string[] }[] = [
       "esb_id",
     ],
   },
-  { field: "player_name", aliases: ["full_name", "player", "player_name"] },
+  { field: "player_name", aliases: ["full_name", "player", "player_name", "player_display_name"] },
   { field: "team", aliases: ["team", "posteam", "team_abbr", "club_code", "team_code", "recent_team"] },
   { field: "position", aliases: ["position", "pos", "depth_chart_position"] },
   { field: "week", aliases: ["week", "game_week", "week_num", "week_number"] },
@@ -442,6 +443,7 @@ const resolvePlayerId = (values: string[], fallback: string): string => {
 
 const resolveIdCandidates = (row: CsvRow): string[] => unique([
   toString(row.player_id),
+  toString(row.player_gsis_id),
   toString(row.gsis_id),
   toString(row.gsis_it_id),
   toString(row.gsis_player_id),
@@ -454,6 +456,8 @@ const resolveIdCandidates = (row: CsvRow): string[] => unique([
 const resolveName = (row: CsvRow): string => {
   const full = toString(row.full_name);
   if (full) return full;
+  const display = toString(row.player_display_name);
+  if (display) return display;
   const player = toString(row.player);
   if (player) return player;
   const playerName = toString(row.player_name);

--- a/tests/apiScoresFallback.test.js
+++ b/tests/apiScoresFallback.test.js
@@ -17,9 +17,9 @@ test('scores API uses stat fallback to populate colleges', async (t) => {
   const httpModule = loadTsModule(path.resolve(__dirname, '../lib/http.ts'));
 
   const statsCsv = [
-    'season,week,player_id,player,team,position,passing_yards,passing_tds,interceptions,rushing_yards,rushing_tds,receptions,receiving_yards,receiving_tds,fumbles_lost,field_goals_made,extra_points_made,gsis_id',
-    '2025,1,alpha,Unknown Player,HOU,WR,0,0,0,0,0,7,110,1,0,0,0,12',
-    '2025,1,beta,J. Hurts,PHI,QB,200,2,1,60,1,0,0,0,0,0,0,00-0033559',
+    'season,week,player_gsis_id,player_display_name,recent_team,position,passing_yards,passing_tds,interceptions,rushing_yards,rushing_tds,receptions,receiving_yards,receiving_tds,fumbles_lost,field_goals_made,extra_points_made',
+    '2025,1,alpha,Unknown Player,HOU,WR,0,0,0,0,0,7,110,1,0,0,0',
+    '2025,1,00-0033559,J. Hurts,PHI,QB,200,2,1,60,1,0,0,0,0,0,0',
   ].join('\n');
   const statsBuffer = zlib.gzipSync(Buffer.from(statsCsv, 'utf8'));
   const playersCsv = [


### PR DESCRIPTION
## Summary
- extend nflverse stat verification to accept `player_gsis_id` and `player_display_name`
- use the new identifiers when resolving player ids and names so college lookups succeed
- update the scores API fallback test to mimic the latest csv header names

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03348a2048332b14ad7f0989c364c