### PR TITLE
Include performer college information

### DIFF
--- a/app/rankings/page.tsx
+++ b/app/rankings/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { fetchJson, friendlyErrorMessage } from "@/lib/clientFetch";
-type Row = { school:string; totalPoints:number; performers:any[] };
+type Performer = { name:string; position:string; team?:string; points:number; college?:string|null; meta?:any };
+type Row = { school:string; totalPoints:number; performers:Performer[] };
 type Api = { season:number; week:number; format:string; mode:'weekly'|'avg'; includeK:boolean; defense:'none'|'approx'; count:number; results: Row[] };
 export default function RankingsPage() {
   const [season,setSeason]=useState("2025"), [week,setWeek]=useState("1"), [format,setFormat]=useState("ppr");
@@ -44,10 +45,10 @@ export default function RankingsPage() {
     {loading && <div>Loading…</div>}{error && <div style={{color:'salmon'}}><b>Error:</b> {error}</div>}
     <div style={{ overflowX:'auto', marginTop:12 }}><table style={{ width:'100%', borderCollapse:'collapse' }}>
       <thead><tr><th style={{textAlign:'left'}}>Rank</th><th style={{textAlign:'left'}}>School</th><th style={{textAlign:'right'}}>Points</th><th style={{textAlign:'left'}}>Top Performers</th></tr></thead>
-      <tbody>{data?.results?.map((row:any, idx:number)=>(<tr key={row.school} style={{ borderTop:'1px solid #1e293b' }}>
+      <tbody>{data?.results?.map((row, idx)=>(<tr key={row.school} style={{ borderTop:'1px solid #1e293b' }}>
         <td>#{idx+1}</td><td><Link href={`/schools/${encodeURIComponent(row.school)}`}>{row.school}</Link></td>
         <td style={{ textAlign:'right' }}>{row.totalPoints.toFixed(1)}</td>
-        <td><ul>{row.performers.slice(0,3).map((p:any,i:number)=>(<li key={i}>{p.name} ({p.position}{p.team?`/${p.team}`:''}) — {p.points}</li>))}</ul></td>
+        <td><ul>{row.performers.slice(0,3).map((p,i)=>(<li key={i}>{p.name} ({p.position}{p.team?`/${p.team}`:''}){p.college?` — ${p.college}`:''} — {p.points}</li>))}</ul></td>
       </tr>))}</tbody></table></div>
   </div>);
 }

--- a/app/schools/[school]/page.tsx
+++ b/app/schools/[school]/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { fetchJson, friendlyErrorMessage } from "@/lib/clientFetch";
-type SeriesPoint = { week:number; totalPoints:number; performers:{name:string; position:string; team?:string; points:number; meta?:any}[] };
+type Performer = { name:string; position:string; team?:string; points:number; college?:string|null; meta?:any };
+type SeriesPoint = { week:number; totalPoints:number; performers:Performer[] };
 type Api = { school:string; season:number; format:string; mode:'weekly'|'avg'; includeK:boolean; defense:'none'|'approx'; series: SeriesPoint[] };
 export default function SchoolDetail({ params }: { params: { school: string } }) {
   const { school } = params; const sp = useSearchParams(); const router = useRouter();
@@ -39,14 +40,14 @@ export default function SchoolDetail({ params }: { params: { school: string } })
   useEffect(()=>{ void refresh(); }, [school]);
   const chartData = (data?.series??[]).map(p=>({ week: p.week, points: p.totalPoints }));
 
-  const renderPerformer = (p: any) => {
+  const renderPerformer = (p: Performer) => {
     if ((p.position||'').toUpperCase()==='DEF' && p.meta?.contributors) {
       const tip = p.meta.contributors.map((c:any)=>`${c.label}: ${c.points.toFixed?c.points.toFixed(1):c.points}`).join('\n');
       return (<details style={{cursor:'pointer'}} title={tip}><summary>Defense — {p.points?.toFixed ? p.points.toFixed(1) : p.points} pts</summary>
         <ul>{p.meta.contributors.map((c:any,idx:number)=>(<li key={idx}>{c.label} — {c.points.toFixed?c.points.toFixed(2):c.points}</li>))}</ul>
       </details>);
     }
-    return (<span>{p.name} ({p.position}{p.team?`/${p.team}`:''}) — {p.points}</span>);
+    return (<span>{p.name} ({p.position}{p.team?`/${p.team}`:''}){p.college?` — ${p.college}`:''} — {p.points}</span>);
   };
 
   if (loading) return <div className="card"><h2>Loading {school}…</h2></div>;

--- a/app/schools/page.tsx
+++ b/app/schools/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { fetchJson, friendlyErrorMessage } from "@/lib/clientFetch";
-type Row = { school:string; week:number; format:string; totalPoints:number; performers:{name:string; position:string; team?:string; points:number; meta?:any}[] };
+type Performer = { name:string; position:string; team?:string; points:number; college?:string|null; meta?:any };
+type Row = { school:string; week:number; format:string; totalPoints:number; performers:Performer[] };
 type Api = { season:number; week:number; format:string; mode:'weekly'|'avg'; includeK:boolean; defense:'none'|'approx'; count:number; results: Row[] };
 export default function SchoolsPage() {
   const [data,setData] = useState<Api|null>(null), [loading,setLoading]=useState(true), [error,setError]=useState<string|null>(null);
@@ -43,7 +44,7 @@ export default function SchoolsPage() {
       {data?.results.map(row => (<div key={row.school} className="card">
         <h3 style={{marginTop:0}}><Link href={`/schools/${encodeURIComponent(row.school)}`}>{row.school}</Link></h3>
         <div className="badge">{row.totalPoints.toFixed(1)} pts</div>
-        <ul>{row.performers.slice(0,5).map((p,idx)=>(<li key={idx}>{p.name} ({p.position}{p.team?`/${p.team}`:''}) — {p.points}</li>))}</ul>
+        <ul>{row.performers.slice(0,5).map((p,idx)=>(<li key={idx}>{p.name} ({p.position}{p.team?`/${p.team}`:''}){p.college?` — ${p.college}`:''} — {p.points}</li>))}</ul>
       </div>))}
     </div>
   </div>);

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -58,7 +58,14 @@ export async function aggregateByCollegeMode(
 
     results.push({
       school, week, format, totalPoints: Number(total.toFixed(2)),
-      performers: chosen.map(p => ({ name: (p as any).full_name, position: (p as any).position, team: (p as any).team, points: thisWeekPoints[String((p as any).player_id)] ?? (p as any).points, meta: (p as any).meta }))
+      performers: chosen.map(p => ({
+        name: (p as any).full_name,
+        position: (p as any).position,
+        team: (p as any).team,
+        points: thisWeekPoints[String((p as any).player_id)] ?? (p as any).points,
+        college: (p as Leader).college,
+        meta: (p as any).meta
+      }))
     });
   }
   results.sort((a,b)=>b.totalPoints - a.totalPoints); return results;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,5 +2,5 @@
 export type Leader = { player_id: string | number; full_name: string; position: string; team?: string; points: number; college?: string | null; };
 export type SchoolAggregate = {
   school: string; week: number; format: string; totalPoints: number;
-  performers: { name: string; position: string; team?: string; points: number; meta?: any }[];
+  performers: { name: string; position: string; team?: string; points: number; college?: string | null; meta?: any }[];
 };

--- a/tests/apiScoresFallback.test.js
+++ b/tests/apiScoresFallback.test.js
@@ -65,4 +65,20 @@ test('scores API uses stat fallback to populate colleges', async (t) => {
   assert.ok(new Set(schools).size >= 2, 'expected multiple schools from players master join');
   assert.ok(schools.includes('Rice'), 'expected Rice mapping from players master');
   assert.ok(schools.includes('Oklahoma'), 'expected Oklahoma mapping from players master alt id');
+
+  for (const entry of payload.results) {
+    for (const performer of entry.performers) {
+      assert.ok(Object.prototype.hasOwnProperty.call(performer, 'college'), 'performer payload should include college field');
+    }
+  }
+
+  const rice = payload.results.find((entry) => entry.school === 'Rice');
+  assert.ok(rice, 'expected Rice entry in results');
+  assert.ok(rice.performers.some((performer) => performer.college === 'Rice'), 'expected Rice performers to include college data');
+
+  const oklahoma = payload.results.find((entry) => entry.school === 'Oklahoma');
+  assert.ok(oklahoma, 'expected Oklahoma entry in results');
+  const qb = oklahoma.performers.find((performer) => (performer.position || '').toUpperCase() === 'QB');
+  assert.ok(qb, 'expected quarterback performer for Oklahoma');
+  assert.equal(qb.college, 'Oklahoma');
 });


### PR DESCRIPTION
## Summary
- add a college field to SchoolAggregate performers and populate it from leader data
- surface performer college names across the schools and rankings pages
- extend the API fallback test to assert performer colleges are returned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d153f0c03c8332b8ef51251e0cfc5b