### PR TITLE
Enable defensive scoring across pages

### DIFF
--- a/app/api/matchup/route.ts
+++ b/app/api/matchup/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: Request) {
     const format = parseStringParam(url, "format", "ppr", { maxLength: 32, toLowerCase: true });
     const mode = parseEnumParam(url, "mode", ["weekly", "avg"] as const, "weekly");
     const includeK = parseBooleanParam(url, "includeK", true);
-    const defense = parseEnumParam(url, "defense", ["none", "approx"] as const, "none");
+    const defense = parseEnumParam(url, "defense", ["none", "approx"] as const, "approx");
     const home = parseRequiredString(url, "home", { maxLength: 120 });
     const away = parseRequiredString(url, "away", { maxLength: 120 });
     Object.assign(input, { season, week, format, mode, includeK, defense, home, away });

--- a/app/api/school/[school]/route.ts
+++ b/app/api/school/[school]/route.ts
@@ -28,7 +28,7 @@ export async function GET(req: Request, { params }: { params: { school: string }
     const format = parseStringParam(url, "format", "ppr", { maxLength: 32, toLowerCase: true });
     const mode = parseEnumParam(url, "mode", ["weekly", "avg"] as const, "weekly");
     const includeK = parseBooleanParam(url, "includeK", true);
-    const defense = parseEnumParam(url, "defense", ["none", "approx"] as const, "none");
+    const defense = parseEnumParam(url, "defense", ["none", "approx"] as const, "approx");
     Object.assign(input, { season, startWeek, endWeek, format, mode, includeK, defense });
     const schoolParamRaw = decodeURIComponent(params.school ?? "");
     const schoolParam = schoolParamRaw.trim();

--- a/app/api/scores/route.ts
+++ b/app/api/scores/route.ts
@@ -24,7 +24,7 @@ export async function GET(req: Request) {
     const format = parseStringParam(url, "format", "ppr", { maxLength: 32, toLowerCase: true });
     const mode = parseEnumParam(url, "mode", ["weekly", "avg"] as const, "weekly");
     const includeK = parseBooleanParam(url, "includeK", true);
-    const defense = parseEnumParam(url, "defense", ["none", "approx"] as const, "none");
+    const defense = parseEnumParam(url, "defense", ["none", "approx"] as const, "approx");
     Object.assign(input, { season, week, format, mode, includeK, defense });
     const includeDefense = defense === "approx";
     const weekPromise = loadWeek({ season, week, format, includeDefense });

--- a/app/matchups/page.tsx
+++ b/app/matchups/page.tsx
@@ -7,7 +7,7 @@ type MatchResp = { season:number; week:number; format:string; mode:'weekly'|'avg
   home:string; away:string; homePoints:number; awayPoints:number; winner:'home'|'away'|'tie'; homeLineup:Performer[]; awayLineup:Performer[] };
 export default function MatchupsPage() {
   const [season,setSeason]=useState("2025"); const [week,setWeek]=useState("2"); const [format,setFormat]=useState("ppr");
-  const [mode,setMode]=useState<"weekly"|"avg">("weekly"); const [includeK,setIncludeK]=useState(true); const [defense,setDefense]=useState<'none'|'approx'>('none');
+  const [mode,setMode]=useState<"weekly"|"avg">("weekly"); const [includeK,setIncludeK]=useState(true); const [defense,setDefense]=useState<'none'|'approx'>('approx');
   const [home,setHome]=useState("Michigan"); const [away,setAway]=useState("Oklahoma"); const [record,setRecord]=useState(false);
   const [data,setData]=useState<MatchResp|null>(null); const [loading,setLoading]=useState(false); const [error,setError]=useState<string|null>(null);
 

--- a/app/rankings/page.tsx
+++ b/app/rankings/page.tsx
@@ -14,7 +14,7 @@ export default function RankingsPage() {
     setLoading(true);
     setError(null);
     try {
-      const q = new URLSearchParams({ season, week, format, mode, includeK: String(true), defense: "none" }).toString();
+      const q = new URLSearchParams({ season, week, format, mode, includeK: String(true), defense: "approx" }).toString();
       const response = await fetchJson<Api>(`/api/scores?${q}`);
       if (response && typeof response === "object" && "error" in response) {
         const message = typeof (response as { error?: unknown }).error === "string"
@@ -33,7 +33,7 @@ export default function RankingsPage() {
   };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(()=>{ void load(); }, []);
-  return (<div className="card"><h2>Rankings — Week {data?.week ?? week} ({data?.format?.toUpperCase() ?? format.toUpperCase()})</h2>
+  return (<div className="card"><h2>Rankings — Week {data?.week ?? week} ({data?.format?.toUpperCase() ?? format.toUpperCase()} + DEF)</h2>
     <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit,minmax(160px,1fr))', gap:12, margin:'12px 0' }}>
       <label>Season<input type="number" value={season} onChange={e=>setSeason(e.target.value)} style={{ marginLeft:8, width:100 }}/></label>
       <label>Week<input type="number" min={1} max={18} value={week} onChange={e=>setWeek(e.target.value)} style={{ marginLeft:8, width:80 }}/></label>

--- a/app/schools/[school]/page.tsx
+++ b/app/schools/[school]/page.tsx
@@ -9,9 +9,10 @@ type SeriesPoint = { week:number; totalPoints:number; performers:Performer[] };
 type Api = { school:string; season:number; format:string; mode:'weekly'|'avg'; includeK:boolean; defense:'none'|'approx'; series: SeriesPoint[] };
 export default function SchoolDetail({ params }: { params: { school: string } }) {
   const { school } = params; const sp = useSearchParams(); const router = useRouter();
+  const initialDefenseParam = (sp.get("defense") as 'none'|'approx'|null);
   const [format,setFormat]=useState(sp.get("format")??"ppr"); const [season,setSeason]=useState(sp.get("season")??"2025");
   const [mode,setMode]=useState<"weekly"|"avg">((sp.get("mode") as any)??"weekly"); const [includeK,setIncludeK]=useState(true);
-  const [defense,setDefense]=useState<'none'|'approx'>((sp.get("defense") as any)??'none');
+  const [defense,setDefense]=useState<'none'|'approx'>(initialDefenseParam === 'none' ? 'none' : 'approx');
   const [startWeek,setStartWeek]=useState(sp.get("startWeek")??"1"); const [endWeek,setEndWeek]=useState(sp.get("endWeek")??"18");
   const [data,setData]=useState<Api|null>(null), [loading,setLoading]=useState(true), [error,setError]=useState<string|null>(null);
   const refresh = async () => {
@@ -54,7 +55,7 @@ export default function SchoolDetail({ params }: { params: { school: string } })
   if (error) return <div className="card"><h2>Error</h2><pre>{error}</pre></div>;
 
   return (<div className="card">
-    <h2>{data?.school} — Week-by-Week ({data?.format?.toUpperCase()})</h2>
+    <h2>{data?.school} — Week-by-Week ({data?.format?.toUpperCase()} + DEF)</h2>
     <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit,minmax(160px,1fr))', gap:12, margin:'12px 0' }}>
       <label>Season<input type="number" value={season} onChange={e=>setSeason(e.target.value)} style={{ marginLeft:8, width:100 }}/></label>
       <label>Format<select value={format} onChange={e=>setFormat(e.target.value)} style={{ marginLeft:8 }}><option value="ppr">PPR</option><option value="half-ppr">Half-PPR</option><option value="standard">Standard</option></select></label>

--- a/app/schools/page.tsx
+++ b/app/schools/page.tsx
@@ -14,7 +14,7 @@ export default function SchoolsPage() {
       setLoading(true);
       setError(null);
       try {
-        const response = await fetchJson<Api>(`/api/scores?season=2025&week=1&format=ppr&mode=weekly&includeK=true&defense=none`);
+        const response = await fetchJson<Api>(`/api/scores?season=2025&week=1&format=ppr&mode=weekly&includeK=true&defense=approx`);
         if (response && typeof response === "object" && "error" in response) {
           const message = typeof (response as { error?: unknown }).error === "string"
             ? String((response as { error?: unknown }).error)
@@ -39,7 +39,7 @@ export default function SchoolsPage() {
   }, []);
   if (loading) return <div className="card"><h2>Loading weekly alumni lineup scores…</h2></div>;
   if (error) return <div className="card"><h2>Error</h2><pre>{error}</pre></div>;
-  return (<div className="card"><h2>Week {data?.week} — Alumni Lineup Scores (QB, TE, WR, WR, RB, RB, K?, FLEX)</h2>
+  return (<div className="card"><h2>Week {data?.week} — Alumni Lineup Scores (QB, TE, WR, WR, RB, RB, K?, FLEX, DEF)</h2>
     <div className="list">
       {data?.results.map(row => (<div key={row.school} className="card">
         <h3 style={{marginTop:0}}><Link href={`/schools/${encodeURIComponent(row.school)}`}>{row.school}</Link></h3>

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -16,7 +16,7 @@ const endpoints = [
   },
   {
     name: "scores",
-    path: "/api/scores?season=2025&week=1&format=ppr&mode=weekly&includeK=true&defense=none",
+    path: "/api/scores?season=2025&week=1&format=ppr&mode=weekly&includeK=true&defense=approx",
     validate: (data) => Array.isArray(data?.results) && data.results.length >= 0,
   },
 ];

--- a/tests/apiScoresFallback.test.js
+++ b/tests/apiScoresFallback.test.js
@@ -54,7 +54,7 @@ test('scores API uses stat fallback to populate colleges', async (t) => {
 
   const { GET } = loadTsModule(path.resolve(__dirname, '../app/api/scores/route.ts'));
 
-  const response = await GET(new Request('http://test/api/scores?season=2025&week=1&format=ppr&mode=weekly'));
+  const response = await GET(new Request('http://test/api/scores?season=2025&week=1&format=ppr&mode=weekly&defense=none'));
   assert.equal(response.status, 200);
 
   const payload = await response.json();


### PR DESCRIPTION
## Summary
- Default the scores, matchup, and school endpoints to include approximate defensive scoring.
- Update the rankings, school, and matchup client pages to request and surface defensive totals by default.
- Align the smoke test script and API fallback test with the new defensive default.

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a2411d308332bb7ab2bebf566744