### PR TITLE
Fix defense scoring and slug encoding issues

### DIFF
--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -5,8 +5,15 @@ import { normalizeTeamAbbreviation, type DefenseWeek } from "./nflverse";
 type Mode = 'weekly' | 'avg';
 type DefenseMode = 'none' | 'approx';
 
-function byPosition(players: Leader[], pos: string) { return players.filter(p => (p.position||'').toUpperCase() === pos.toUpperCase()); }
-function isDefPos(pos?: string) { const p=(pos||'').toUpperCase(); return ['LB','DB','DL','DE','DT','S','CB','OLB','ILB','EDGE','FS','SS','NT','MLB','NB','SAF'].includes(p); }
+const normalizePosition = (pos?: string): string => (pos ?? "").toString().trim().toUpperCase();
+function byPosition(players: Leader[], pos: string) {
+  const target = normalizePosition(pos);
+  return players.filter((player) => normalizePosition(player.position) === target);
+}
+function isDefPos(pos?: string) {
+  const normalized = normalizePosition(pos);
+  return ['LB', 'DB', 'DL', 'DE', 'DT', 'S', 'CB', 'OLB', 'ILB', 'EDGE', 'FS', 'SS', 'NT', 'MLB', 'NB', 'SAF'].includes(normalized);
+}
 function sortBy(points: Record<string, number>) { return (a: Leader, b: Leader) => (points[String(b.player_id)] ?? 0) - (points[String(a.player_id)] ?? 0); }
 function lineupForSchool(players: Leader[], selectorPoints: Record<string, number>, includeK: boolean) {
   const qbs=byPosition(players,'QB').sort(sortBy(selectorPoints)), rbs=byPosition(players,'RB').sort(sortBy(selectorPoints)), wrs=byPosition(players,'WR').sort(sortBy(selectorPoints)), tes=byPosition(players,'TE').sort(sortBy(selectorPoints)), ks=byPosition(players,'K').sort(sortBy(selectorPoints));


### PR DESCRIPTION
## Summary
- Normalize player positions while building lineups so defensive contributors are recognized and their fantasy points are applied.
- Decode school slugs before updating URLs to prevent repeated percent-encoding and display trimmed position labels.
- Clear corrupted cached nflverse assets and retry gzip extraction to avoid unexpected EOF errors when loading weekly data.

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f73244c88332bf2eb964665b2b52