### PR TITLE
Handle new nflverse team defense columns

### DIFF
--- a/lib/defense.ts
+++ b/lib/defense.ts
@@ -104,13 +104,43 @@ export type DefenseApproxResult = {
 };
 
 const KEY_CANDIDATES = {
-  team: ["team", "team_abbr", "posteam", "abbr"] as const,
-  opponent: ["opponent", "opp", "defteam", "opp_abbr"] as const,
-  week: ["week", "game_week", "wk"] as const,
-  pointsFor: ["points_scored", "points", "pts"] as const,
-  sacks: ["sacks", "pass_sacks", "sacks_allowed"] as const,
-  interceptions: ["interceptions", "int", "ints", "pass_interceptions"] as const,
-  fumbles: ["fumbles_lost", "fumbles", "fumlost"] as const,
+  team: [
+    "team",
+    "team_abbr",
+    "posteam",
+    "abbr",
+    "club_code",
+    "team_code",
+    "recent_team",
+  ] as const,
+  opponent: [
+    "opponent",
+    "opp",
+    "defteam",
+    "opp_abbr",
+    "opponent_team",
+    "opponent_team_abbr",
+    "opp_team",
+    "opp_club_code",
+  ] as const,
+  week: ["week", "game_week", "wk", "week_num", "week_number"] as const,
+  pointsFor: ["points_scored", "points", "pts", "points_for", "points_for_total"] as const,
+  sacks: ["sacks", "pass_sacks", "sacks_allowed", "pass_sacks_allowed", "sacks_taken"] as const,
+  interceptions: [
+    "interceptions",
+    "int",
+    "ints",
+    "pass_interceptions",
+    "interceptions_thrown",
+    "pass_interceptions_thrown",
+  ] as const,
+  fumbles: [
+    "fumbles_lost",
+    "fumbles",
+    "fumlost",
+    "fumbles_lost_offense",
+    "fumbles_lost_total",
+  ] as const,
 } as const satisfies Record<string, KeyList>;
 
 async function fetchSeasonCsv(season: number): Promise<string> {

--- a/tests/defenseApprox.test.js
+++ b/tests/defenseApprox.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { loadTsModule } = require('./helpers/loadTsModule');
+
+const modulePath = path.resolve(__dirname, '../lib/defense.ts');
+
+const SAMPLE_CSV = [
+  'season,week_num,club_code,opp_club_code,points_for,pass_sacks_allowed,interceptions_thrown,fumbles_lost_offense',
+  '2025,3,PHI,DAL,24,1,0,1',
+  '2025,3,DAL,PHI,21,3,2,2',
+].join('\n');
+
+test('fetchDefenseApprox reads modern team columns', async (t) => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    text: async () => SAMPLE_CSV,
+  });
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+
+  const { fetchDefenseApprox } = loadTsModule(modulePath);
+  const result = await fetchDefenseApprox({ season: 2025, week: 3 });
+
+  assert.equal(result.week, 3);
+  assert.equal(result.rows.length, 2);
+
+  const phi = result.rows.find((row) => row.team === 'PHI');
+  assert.ok(phi, 'expected PHI defense row');
+  assert.equal(phi.points_allowed, 21);
+  assert.equal(phi.sacks, 3);
+  assert.equal(phi.interceptions, 2);
+  assert.equal(phi.fumbles_recovered, 2);
+  assert.equal(phi.score, 11);
+
+  const dal = result.rows.find((row) => row.team === 'DAL');
+  assert.ok(dal, 'expected DAL defense row');
+  assert.equal(dal.points_allowed, 24);
+  assert.equal(dal.sacks, 1);
+  assert.equal(dal.interceptions, 0);
+  assert.equal(dal.fumbles_recovered, 1);
+  assert.equal(dal.score, 3);
+});


### PR DESCRIPTION
## Summary
- expand team defense CSV column candidates to cover new nflverse field names
- ensure approximate defense loader produces non-empty rows when only modern columns exist
- add regression test covering club_code and week_num inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d41aa074d483328f0847304d5e3361