### PR TITLE
Improve defense API client wiring

### DIFF
--- a/app/debug/defense/page.tsx
+++ b/app/debug/defense/page.tsx
@@ -5,9 +5,15 @@ import { fetchDefense, type DefenseRow } from "@/utils/fetchDefense";
 export default function DebugDefense() {
   const [rows, setRows] = useState<DefenseRow[]>([]);
   const [err, setErr] = useState<string>("");
+  const [meta, setMeta] = useState<{ week: number; mode?: string; source?: string } | null>(null);
 
   useEffect(() => {
-    fetchDefense(2025).then(setRows).catch((e) => setErr(String(e)));
+    fetchDefense(2025)
+      .then((result) => {
+        setRows(result.rows);
+        setMeta({ week: result.week, mode: result.mode, source: result.source });
+      })
+      .catch((e) => setErr(String(e)));
   }, []);
 
   if (err) return <div className="p-4 text-red-600">Error: {err}</div>;
@@ -15,7 +21,15 @@ export default function DebugDefense() {
 
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Defense Debug (2025)</h1>
+      <h1 className="text-2xl font-bold">
+        Defense Debug (2025{meta?.week ? ` — Week ${meta.week}` : ""})
+      </h1>
+      {meta?.mode && (
+        <div className="text-sm text-slate-400">
+          Mode: {meta.mode}
+          {meta.source ? ` · Source: ${meta.source}` : ""}
+        </div>
+      )}
       <table className="min-w-full text-sm">
         <thead>
           <tr>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,8 +44,14 @@ export default async function HomePage() {
     const defense = await fetchDefenseApprox({ season: DEFAULT_SEASON });
     if (defense.rows.length === 0) {
       defenseBanner = "Defense stats not posted yet; check back later.";
-    } else if (defense.rows.every((row) => Number(row.score) === 0)) {
-      showApproxBadge = true;
+    } else {
+      showApproxBadge = defense.mode === "approx-opponent-offense";
+      if (defense.rows.every((row) => Number(row.score) === 0)) {
+        console.warn("[home] Defense approx returned zero scores", {
+          season: DEFAULT_SEASON,
+          week: defense.week,
+        });
+      }
     }
   } catch (err) {
     if (err instanceof DefenseUnavailableError) {

--- a/utils/fetchDefense.ts
+++ b/utils/fetchDefense.ts
@@ -1,3 +1,28 @@
+const TEAM_ALIAS: Record<string, string> = {
+  JAX: "JAC",
+  WSH: "WAS",
+  LA: "LAR",
+};
+
+const normalizeTeam = (value: unknown): string => {
+  const raw = typeof value === "string" ? value : String(value ?? "");
+  const trimmed = raw.trim().toUpperCase();
+  if (!trimmed) return "";
+  return TEAM_ALIAS[trimmed] ?? trimmed;
+};
+
+const toNumber = (value: unknown): number => {
+  if (value === null || value === undefined) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const toWeek = (value: unknown): number => {
+  const parsed = toNumber(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.trunc(parsed);
+};
+
 export type DefenseRow = {
   team: string;
   week: number;
@@ -8,12 +33,50 @@ export type DefenseRow = {
   score: number;
 };
 
-export async function fetchDefense(season = 2025, week?: number): Promise<DefenseRow[]> {
+export type DefenseApiResponse = {
+  season: number;
+  week: number;
+  mode?: string;
+  source?: string;
+  rows: DefenseRow[];
+};
+
+export async function fetchDefense(season = 2025, week?: number): Promise<DefenseApiResponse> {
   const qs = new URLSearchParams({ season: String(season) });
   if (week != null) qs.set("week", String(week));
   const r = await fetch(`/api/defense?${qs.toString()}`, { cache: "no-store" });
   const j = await r.json();
   if (!r.ok) throw new Error(j?.error || r.statusText);
-  console.log("[alumni] DEF", { source: j.source, week: j.week, mode: j.mode, rows: j.rows.length });
-  return j.rows as DefenseRow[];
+
+  const responseWeek = toWeek(j?.week ?? week);
+  const rows = Array.isArray(j?.rows)
+    ? (j.rows as Record<string, unknown>[])
+        .map((row) => ({
+          team: normalizeTeam(row.team),
+          week: toWeek(row.week ?? responseWeek),
+          points_allowed: toNumber(row.points_allowed),
+          sacks: toNumber(row.sacks),
+          interceptions: toNumber(row.interceptions),
+          fumbles_recovered: toNumber(row.fumbles_recovered),
+          score: toNumber(row.score),
+        }))
+        .filter((row) => row.team.length > 0)
+    : [];
+
+  const payload: DefenseApiResponse = {
+    season: toWeek(j?.season) || season,
+    week: responseWeek,
+    mode: typeof j?.mode === "string" ? j.mode : undefined,
+    source: typeof j?.source === "string" ? j.source : undefined,
+    rows,
+  };
+
+  console.log("[alumni] DEF", {
+    source: payload.source,
+    week: payload.week,
+    mode: payload.mode,
+    rows: payload.rows.length,
+  });
+
+  return payload;
 }


### PR DESCRIPTION
## Summary
- normalize team codes and numeric fields in the `/api/defense` client helper while returning response metadata
- surface defense API metadata in the debug page and defense status hook, including week-mismatch handling
- base the home page badge on the API mode and warn if the defense feed still reports zero scores

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44bcd2f388332b0740b95624d1ce1