### PR TITLE
Handle defense week fallbacks

### DIFF
--- a/app/debug/defense/page.tsx
+++ b/app/debug/defense/page.tsx
@@ -2,16 +2,32 @@
 import { useEffect, useState } from "react";
 import { fetchDefense, type DefenseRow } from "@/utils/fetchDefense";
 
+type DefenseMeta = {
+  week: number;
+  mode?: string;
+  source?: string;
+  fallback_reason?: string | null;
+  requested_week?: number | null;
+  weeks_available?: number[];
+};
+
 export default function DebugDefense() {
   const [rows, setRows] = useState<DefenseRow[]>([]);
   const [err, setErr] = useState<string>("");
-  const [meta, setMeta] = useState<{ week: number; mode?: string; source?: string } | null>(null);
+  const [meta, setMeta] = useState<DefenseMeta | null>(null);
 
   useEffect(() => {
     fetchDefense(2025)
       .then((result) => {
         setRows(result.rows);
-        setMeta({ week: result.week, mode: result.mode, source: result.source });
+        setMeta({
+          week: result.week,
+          mode: result.mode,
+          source: result.source,
+          fallback_reason: result.fallback_reason ?? null,
+          requested_week: result.requested_week ?? null,
+          weeks_available: result.weeks_available,
+        });
       })
       .catch((e) => setErr(String(e)));
   }, []);
@@ -24,10 +40,28 @@ export default function DebugDefense() {
       <h1 className="text-2xl font-bold">
         Defense Debug (2025{meta?.week ? ` — Week ${meta.week}` : ""})
       </h1>
-      {meta?.mode && (
-        <div className="text-sm text-slate-400">
-          Mode: {meta.mode}
-          {meta.source ? ` · Source: ${meta.source}` : ""}
+      {meta && (
+        <div className="text-sm text-slate-400 space-y-1">
+          {(meta.mode || meta.source) && (
+            <div>
+              {meta.mode ? `Mode: ${meta.mode}` : null}
+              {meta.mode && meta.source ? " · " : ""}
+              {meta.source ? `Source: ${meta.source}` : null}
+            </div>
+          )}
+          {(meta.fallback_reason || meta.requested_week != null || meta.weeks_available?.length) && (
+            <div className="text-xs text-amber-500 space-x-2">
+              {meta.requested_week != null ? <span>Requested: W{meta.requested_week}</span> : null}
+              {meta.fallback_reason ? <span>Fallback: {meta.fallback_reason}</span> : null}
+              {meta.weeks_available?.length ? (
+                <span>
+                  Weeks available: {meta.weeks_available.length > 6
+                    ? `${meta.weeks_available.slice(0, 3).join(", ")} … ${meta.weeks_available.slice(-3).join(", ")}`
+                    : meta.weeks_available.join(", ")}
+                </span>
+              ) : null}
+            </div>
+          )}
         </div>
       )}
       <table className="min-w-full text-sm">


### PR DESCRIPTION
## Summary
- fallback to the latest available team stats week when a requested week is missing and surface metadata about the selection
- teach the defense fetcher to retry with the latest available week and return the new metadata fields
- display fallback and availability details on the defense debug view so the UI reflects what was returned

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d45232b23883328204981618bd1593