### PR TITLE
Include DEF position in defense credit selection

### DIFF
--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -12,7 +12,7 @@ function byPosition(players: Leader[], pos: string) {
 }
 function isDefPos(pos?: string) {
   const normalized = normalizePosition(pos);
-  return ['LB', 'DB', 'DL', 'DE', 'DT', 'S', 'CB', 'OLB', 'ILB', 'EDGE', 'FS', 'SS', 'NT', 'MLB', 'NB', 'SAF'].includes(normalized);
+  return ['LB', 'DB', 'DL', 'DE', 'DT', 'S', 'CB', 'OLB', 'ILB', 'EDGE', 'FS', 'SS', 'NT', 'MLB', 'NB', 'SAF', 'DEF'].includes(normalized);
 }
 function sortBy(points: Record<string, number>) { return (a: Leader, b: Leader) => (points[String(b.player_id)] ?? 0) - (points[String(a.player_id)] ?? 0); }
 function lineupForSchool(players: Leader[], selectorPoints: Record<string, number>, includeK: boolean) {


### PR DESCRIPTION
## Summary
- count defensive players labeled with the generic DEF position when allocating DST points

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d455c909848332bd7b4a299502c5ab