### PR TITLE
Add alumni matchup API and team game results table

### DIFF
--- a/app/api/alumni/team/[season]/[team]/route.ts
+++ b/app/api/alumni/team/[season]/[team]/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { kvGet, kvSet } from "@/lib/kv";
+import { getCfbTeamSeasonGames } from "@/utils/schedules";
+import {
+  getWeeklyStats,
+  getRosterWithColleges,
+  joinStatsToColleges,
+  StatsNotAvailableError,
+  normalizeSchool,
+} from "@/utils/datasources";
+import { lastCompletedNflWeek, nflWeekWindowUtc } from "@/utils/nflWeek";
+import type { PlayerWeekly } from "@/utils/compute";
+
+export const runtime = "nodejs";
+
+type ResultRow = {
+  cfbWeek: number;
+  cfbDate: string;
+  homeAway: "Home" | "Away";
+  opponent: string;
+  usPts: number;
+  oppPts: number;
+  result: "W" | "L" | "T";
+  nflSeason: number;
+  nflWeek: number;
+  nflWindowStart: string;
+  nflWindowEnd: string;
+};
+
+type PendingPayload = {
+  status: "pending";
+  message: string;
+  season: number;
+  week: number;
+};
+
+const CACHE_TTL_SECONDS = 60 * 60 * 24;
+
+const roundOne = (value: number): number => Number(value.toFixed(1));
+
+const sumForMatchup = (rows: PlayerWeekly[], home: string, away: string) => {
+  const want = new Set([home, away]);
+  const totals = new Map<string, number>();
+  totals.set(home, 0);
+  totals.set(away, 0);
+  for (const row of rows) {
+    const college = row.college;
+    if (!college || !want.has(college)) continue;
+    const current = totals.get(college) ?? 0;
+    totals.set(college, current + (row.points ?? 0));
+  }
+  return {
+    home: totals.get(home) ?? 0,
+    away: totals.get(away) ?? 0,
+  };
+};
+
+const buildCacheKey = (season: number, team: string) => `alumni:v1:team:${season}:${team}`;
+
+const buildHeaders = () => ({ "Cache-Control": "s-maxage=3600, stale-while-revalidate=86400" });
+
+export async function GET(
+  _req: Request,
+  context: { params: { season: string; team: string } },
+) {
+  const seasonParam = context.params?.season ?? "";
+  const season = Number.parseInt(seasonParam, 10);
+  if (!Number.isFinite(season) || season < 1900 || season > 2100) {
+    return NextResponse.json({ error: "invalid_season" }, { status: 400 });
+  }
+
+  const rawTeam = decodeURIComponent(context.params?.team ?? "");
+  const normalizedTeam = normalizeSchool(rawTeam);
+  if (!normalizedTeam) {
+    return NextResponse.json({ error: "invalid_team" }, { status: 400 });
+  }
+
+  const cacheKey = buildCacheKey(season, normalizedTeam);
+  const cached = await kvGet<ResultRow[]>(cacheKey);
+  if (cached && cached.length) {
+    return NextResponse.json({ team: normalizedTeam, season, rows: cached, cached: true }, { headers: buildHeaders() });
+  }
+
+  try {
+    const games = (await getCfbTeamSeasonGames(season, rawTeam || normalizedTeam)).filter(
+      (game) => game.home === normalizedTeam || game.away === normalizedTeam,
+    );
+    if (!games.length) {
+      return NextResponse.json({ team: normalizedTeam, season, rows: [] }, { headers: buildHeaders() });
+    }
+
+    const { season: nflSeason, week: nflWeek } = lastCompletedNflWeek();
+    const { startISO, endISO } = nflWeekWindowUtc(nflSeason, nflWeek);
+
+    let stats;
+    try {
+      stats = await getWeeklyStats(nflSeason, nflWeek, "ppr");
+    } catch (error) {
+      if (error instanceof StatsNotAvailableError) {
+        const payload: PendingPayload = {
+          status: "pending",
+          message: "NFL weekly player stats not yet published",
+          season: error.season,
+          week: error.week,
+        };
+        return NextResponse.json(payload, { status: 202, headers: buildHeaders() });
+      }
+      throw error;
+    }
+
+    const roster = await getRosterWithColleges(nflSeason);
+    const joined = await joinStatsToColleges(stats, roster);
+
+    const rows: ResultRow[] = [];
+    for (const game of games) {
+      const totals = sumForMatchup(joined.rows, game.home, game.away);
+      const isHome = game.home === normalizedTeam;
+      const opponent = isHome ? game.away : game.home;
+      const usRaw = isHome ? totals.home : totals.away;
+      const oppRaw = isHome ? totals.away : totals.home;
+      const usPts = roundOne(usRaw);
+      const oppPts = roundOne(oppRaw);
+      const result: ResultRow["result"] = usPts === oppPts ? "T" : usPts > oppPts ? "W" : "L";
+      rows.push({
+        cfbWeek: game.week,
+        cfbDate: game.kickoffISO ? game.kickoffISO.slice(0, 10) : "",
+        homeAway: isHome ? "Home" : "Away",
+        opponent,
+        usPts,
+        oppPts,
+        result,
+        nflSeason,
+        nflWeek,
+        nflWindowStart: startISO,
+        nflWindowEnd: endISO,
+      });
+    }
+
+    rows.sort((a, b) => a.cfbWeek - b.cfbWeek || a.cfbDate.localeCompare(b.cfbDate));
+
+    await kvSet(cacheKey, rows, CACHE_TTL_SECONDS);
+
+    return NextResponse.json({ team: normalizedTeam, season, rows, cached: false }, { headers: buildHeaders() });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("[alumni] team results failed", error);
+    return NextResponse.json({ error: "alumni_team_failed", message: String(error) }, { status: 500 });
+  }
+}

--- a/app/schools/[school]/page.tsx
+++ b/app/schools/[school]/page.tsx
@@ -1,6 +1,6 @@
 
 'use client';
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { fetchJson, friendlyErrorMessage } from "@/lib/clientFetch";
@@ -8,6 +8,21 @@ import { useDefenseStatus } from "@/utils/useDefenseStatus";
 type Performer = { name:string; position:string; team?:string; points:number; college?:string|null; meta?:any };
 type SeriesPoint = { week:number; totalPoints:number; performers:Performer[] };
 type Api = { school:string; season:number; format:string; mode:'weekly'|'avg'; includeK:boolean; defense:'none'|'approx'; series: SeriesPoint[] };
+type GameResultRow = {
+  cfbWeek: number;
+  cfbDate: string;
+  homeAway: "Home" | "Away";
+  opponent: string;
+  usPts: number;
+  oppPts: number;
+  result: "W" | "L" | "T";
+  nflSeason: number;
+  nflWeek: number;
+  nflWindowStart: string;
+  nflWindowEnd: string;
+};
+type GameResultsResponse = { team: string; season: number; rows: GameResultRow[]; cached?: boolean };
+type PendingGameResults = { status: "pending"; message: string; season: number; week: number };
 
 const decodeSchoolParam = (value: string): string => {
   if (!value) return value;
@@ -34,6 +49,10 @@ export default function SchoolDetail({ params }: { params: { school: string } })
   const [defense,setDefense]=useState<'none'|'approx'>(initialDefenseParam === 'none' ? 'none' : 'approx');
   const [startWeek,setStartWeek]=useState(sp.get("startWeek")??"1"); const [endWeek,setEndWeek]=useState(sp.get("endWeek")??"18");
   const [data,setData]=useState<Api|null>(null), [loading,setLoading]=useState(true), [error,setError]=useState<string|null>(null);
+  const [gameResults,setGameResults]=useState<GameResultsResponse|null>(null);
+  const [gameResultsLoading,setGameResultsLoading]=useState(true);
+  const [gameResultsError,setGameResultsError]=useState<string|null>(null);
+  const [gameResultsPending,setGameResultsPending]=useState<PendingGameResults|null>(null);
   const parsedSeason = Number.parseInt(season, 10);
   const parsedEndWeek = Number.parseInt(endWeek, 10);
   const defenseStatus = useDefenseStatus({
@@ -41,11 +60,47 @@ export default function SchoolDetail({ params }: { params: { school: string } })
     week: Number.isFinite(parsedEndWeek) && parsedEndWeek > 0 ? parsedEndWeek : undefined,
     enabled: defense === 'approx',
   });
+  const loadGameResults = async (seasonValue: string) => {
+    setGameResultsLoading(true);
+    setGameResultsError(null);
+    setGameResultsPending(null);
+    const parsed = Number.parseInt(seasonValue, 10);
+    if (!Number.isFinite(parsed) || parsed < 1900 || parsed > 2100) {
+      setGameResults(null);
+      setGameResultsError(`Enter a valid season to load game results for ${normalizedSchool}.`);
+      setGameResultsLoading(false);
+      return;
+    }
+    try {
+      const response = await fetchJson<GameResultsResponse | PendingGameResults>(
+        `/api/alumni/team/${parsed}/${schoolSlug}`,
+      );
+      if (response && typeof response === "object" && "status" in response && response.status === "pending") {
+        setGameResults(null);
+        setGameResultsPending(response);
+        return;
+      }
+      if (response && typeof response === "object" && "rows" in response) {
+        setGameResults(response as GameResultsResponse);
+        setGameResultsPending(null);
+        return;
+      }
+      throw new Error(`Unexpected response loading game results for ${normalizedSchool}`);
+    } catch (e) {
+      console.error(`Failed to load game results for ${normalizedSchool}`, e);
+      setGameResults(null);
+      setGameResultsPending(null);
+      setGameResultsError(friendlyErrorMessage(e, `Unable to load game results for ${normalizedSchool}`));
+    } finally {
+      setGameResultsLoading(false);
+    }
+  };
   const refresh = async () => {
     const q = new URLSearchParams({ season, startWeek, endWeek, format, mode, includeK: String(includeK), defense }).toString();
     router.replace(`/schools/${schoolSlug}?${q}`);
     setLoading(true);
     setError(null);
+    void loadGameResults(season);
     try {
       const response = await fetchJson<Api>(`/api/school/${schoolSlug}?${q}`);
       if (response && typeof response === "object" && "error" in response) {
@@ -66,6 +121,70 @@ export default function SchoolDetail({ params }: { params: { school: string } })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(()=>{ void refresh(); }, [schoolSlug]);
   const chartData = (data?.series??[]).map(p=>({ week: p.week, points: p.totalPoints }));
+  const sortedGameResults = (gameResults?.rows ?? []).slice().sort((a,b)=>{
+    if (a.cfbWeek !== b.cfbWeek) return a.cfbWeek - b.cfbWeek;
+    return a.cfbDate.localeCompare(b.cfbDate);
+  });
+  const windowLabel = (start: string, end: string) => {
+    const format = (value: string) => (value ? value.replace('T', ' ').slice(0, 16) : '—');
+    return `${format(start)} → ${format(end)}`;
+  };
+  const gameResultsSeasonLabel = gameResults?.season ?? (Number.isFinite(parsedSeason) ? parsedSeason : new Date().getFullYear());
+  let gameResultsBody: ReactNode;
+  if (gameResultsLoading) {
+    gameResultsBody = <p>Loading game results…</p>;
+  } else if (gameResultsError) {
+    gameResultsBody = (<div>
+      <h3>Error</h3>
+      <pre style={{ whiteSpace:'pre-wrap' }}>{gameResultsError}</pre>
+    </div>);
+  } else if (gameResultsPending) {
+    gameResultsBody = (
+      <p>
+        NFL stats for {gameResultsPending.season} Week {gameResultsPending.week} are not published yet. Check back soon.
+      </p>
+    );
+  } else if (!sortedGameResults.length) {
+    gameResultsBody = <p>No matchup results yet for {gameResultsSeasonLabel}.</p>;
+  } else {
+    gameResultsBody = (
+      <>
+        <div style={{ overflowX:'auto', marginTop:12 }}>
+          <table style={{ width:'100%', borderCollapse:'collapse', fontSize:'0.9rem' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign:'left', padding:'6px 8px' }}>CFB Wk</th>
+                <th style={{ textAlign:'left', padding:'6px 8px' }}>CFB Date</th>
+                <th style={{ textAlign:'left', padding:'6px 8px' }}>H/A</th>
+                <th style={{ textAlign:'left', padding:'6px 8px' }}>Opponent</th>
+                <th style={{ textAlign:'right', padding:'6px 8px' }}>Alumni Pts (Us–Opp)</th>
+                <th style={{ textAlign:'left', padding:'6px 8px' }}>NFL Week</th>
+                <th style={{ textAlign:'left', padding:'6px 8px' }}>NFL Window (UTC)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedGameResults.map((row, idx) => (
+                <tr key={`${row.cfbWeek}-${row.homeAway}-${row.opponent}-${idx}`} style={{ borderTop:'1px solid #1e293b' }}>
+                  <td style={{ padding:'6px 8px' }}>W{row.cfbWeek}</td>
+                  <td style={{ padding:'6px 8px' }}>{row.cfbDate || 'TBD'}</td>
+                  <td style={{ padding:'6px 8px' }}>{row.homeAway}</td>
+                  <td style={{ padding:'6px 8px' }}>{row.opponent}</td>
+                  <td style={{ padding:'6px 8px', textAlign:'right' }}>
+                    {row.usPts.toFixed(1)}–{row.oppPts.toFixed(1)} ({row.result})
+                  </td>
+                  <td style={{ padding:'6px 8px' }}>{row.nflSeason}-W{row.nflWeek}</td>
+                  <td style={{ padding:'6px 8px' }}>{windowLabel(row.nflWindowStart, row.nflWindowEnd)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p style={{ marginTop:8, fontSize:'0.75rem', color:'#94a3b8' }}>
+          NFL window reflects a Tuesday-to-Tuesday UTC cutoff; swap to true schedule ranges when available.
+        </p>
+      </>
+    );
+  }
 
   const renderPerformer = (p: Performer) => {
     const normalizedPosition = (p.position ?? "").trim().toUpperCase();
@@ -82,39 +201,47 @@ export default function SchoolDetail({ params }: { params: { school: string } })
   if (loading) return <div className="card"><h2>Loading {normalizedSchool}…</h2></div>;
   if (error) return <div className="card"><h2>Error</h2><pre>{error}</pre></div>;
 
-  return (<div className="card">
-    <h2>{data?.school} — Week-by-Week ({data?.format?.toUpperCase()} + DEF)</h2>
-    <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit,minmax(160px,1fr))', gap:12, margin:'12px 0' }}>
-      <label>Season<input type="number" value={season} onChange={e=>setSeason(e.target.value)} style={{ marginLeft:8, width:100 }}/></label>
-      <label>Format<select value={format} onChange={e=>setFormat(e.target.value)} style={{ marginLeft:8 }}><option value="ppr">PPR</option><option value="half-ppr">Half-PPR</option><option value="standard">Standard</option></select></label>
-      <label>Selection Mode<select value={mode} onChange={e=>setMode(e.target.value as any)} style={{ marginLeft:8 }}><option value="weekly">Weekly best</option><option value="avg">Manager (avg to date)</option></select></label>
-      <label>Include K <input type="checkbox" checked={includeK} onChange={e=>setIncludeK(e.target.checked)} style={{ marginLeft:8 }}/></label>
-      <label>Defense<select value={defense} onChange={e=>setDefense(e.target.value as any)} style={{ marginLeft:8 }}><option value="none">None</option><option value="approx">Approx (snap share)</option></select></label>
-      <label>Start Week<input type="number" min={1} max={18} value={startWeek} onChange={e=>setStartWeek(e.target.value)} style={{ marginLeft:8, width:80 }}/></label>
-      <label>End Week<input type="number" min={1} max={18} value={endWeek} onChange={e=>setEndWeek(e.target.value)} style={{ marginLeft:8, width:80 }}/></label>
-      <button className="btn" onClick={refresh}>Update</button>
-    </div>
-    {defense === 'approx' && defenseStatus.message && (
-      <div className="badge" style={{ marginTop: 8, background: '#f97316', color: '#0b1220' }}>
-        Defense stats not posted yet; check back later.
+  return (
+    <div style={{ display:'grid', gap:16 }}>
+      <div className="card">
+        <h2>{data?.school} — Week-by-Week ({data?.format?.toUpperCase()} + DEF)</h2>
+        <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit,minmax(160px,1fr))', gap:12, margin:'12px 0' }}>
+          <label>Season<input type="number" value={season} onChange={e=>setSeason(e.target.value)} style={{ marginLeft:8, width:100 }}/></label>
+          <label>Format<select value={format} onChange={e=>setFormat(e.target.value)} style={{ marginLeft:8 }}><option value="ppr">PPR</option><option value="half-ppr">Half-PPR</option><option value="standard">Standard</option></select></label>
+          <label>Selection Mode<select value={mode} onChange={e=>setMode(e.target.value as any)} style={{ marginLeft:8 }}><option value="weekly">Weekly best</option><option value="avg">Manager (avg to date)</option></select></label>
+          <label>Include K <input type="checkbox" checked={includeK} onChange={e=>setIncludeK(e.target.checked)} style={{ marginLeft:8 }}/></label>
+          <label>Defense<select value={defense} onChange={e=>setDefense(e.target.value as any)} style={{ marginLeft:8 }}><option value="none">None</option><option value="approx">Approx (snap share)</option></select></label>
+          <label>Start Week<input type="number" min={1} max={18} value={startWeek} onChange={e=>setStartWeek(e.target.value)} style={{ marginLeft:8, width:80 }}/></label>
+          <label>End Week<input type="number" min={1} max={18} value={endWeek} onChange={e=>setEndWeek(e.target.value)} style={{ marginLeft:8, width:80 }}/></label>
+          <button className="btn" onClick={refresh}>Update</button>
+        </div>
+        {defense === 'approx' && defenseStatus.message && (
+          <div className="badge" style={{ marginTop: 8, background: '#f97316', color: '#0b1220' }}>
+            Defense stats not posted yet; check back later.
+          </div>
+        )}
+        {defense === 'approx' && !defenseStatus.message && defenseStatus.showApproxBadge && (
+          <div className="badge" style={{ marginTop: 8, background: '#facc15', color: '#0b1220' }}>
+            Approx mode (opponent offense)
+          </div>
+        )}
+        <div style={{ width:'100%', height:320, background:'#0b1220', borderRadius:12, padding:12 }}>
+          <ResponsiveContainer width="100%" height="100%"><LineChart data={chartData}><CartesianGrid strokeDasharray="3 3"/><XAxis dataKey="week"/><YAxis/><Tooltip/><Line type="monotone" dataKey="points" strokeWidth={2} dot={false}/></LineChart></ResponsiveContainer>
+        </div>
+        <div style={{ margin:'16px 0' }}>
+          <table style={{ width:'100%', borderCollapse:'collapse' }}>
+            <thead><tr><th style={{textAlign:'left'}}>Week</th><th style={{textAlign:'right'}}>Points</th><th style={{textAlign:'left'}}>Starters</th></tr></thead>
+            <tbody>{data?.series?.map(row=>(<tr key={row.week} style={{ borderTop:'1px solid #1e293b' }}>
+              <td>W{row.week}</td><td style={{ textAlign:'right' }}>{row.totalPoints.toFixed(1)}</td>
+              <td><ul>{row.performers.map((p,idx)=>(<li key={idx}>{renderPerformer(p)}</li>))}</ul></td>
+            </tr>))}</tbody>
+          </table>
+        </div>
       </div>
-    )}
-    {defense === 'approx' && !defenseStatus.message && defenseStatus.showApproxBadge && (
-      <div className="badge" style={{ marginTop: 8, background: '#facc15', color: '#0b1220' }}>
-        Approx mode (opponent offense)
+      <div className="card">
+        <h2>{normalizedSchool} — Game Results ({gameResultsSeasonLabel})</h2>
+        {gameResultsBody}
       </div>
-    )}
-    <div style={{ width:'100%', height:320, background:'#0b1220', borderRadius:12, padding:12 }}>
-      <ResponsiveContainer width="100%" height="100%"><LineChart data={chartData}><CartesianGrid strokeDasharray="3 3"/><XAxis dataKey="week"/><YAxis/><Tooltip/><Line type="monotone" dataKey="points" strokeWidth={2} dot={false}/></LineChart></ResponsiveContainer>
     </div>
-    <div style={{ margin:'16px 0' }}>
-      <table style={{ width:'100%', borderCollapse:'collapse' }}>
-        <thead><tr><th style={{textAlign:'left'}}>Week</th><th style={{textAlign:'right'}}>Points</th><th style={{textAlign:'left'}}>Starters</th></tr></thead>
-        <tbody>{data?.series?.map(row=>(<tr key={row.week} style={{ borderTop:'1px solid #1e293b' }}>
-          <td>W{row.week}</td><td style={{ textAlign:'right' }}>{row.totalPoints.toFixed(1)}</td>
-          <td><ul>{row.performers.map((p,idx)=>(<li key={idx}>{renderPerformer(p)}</li>))}</ul></td>
-        </tr>))}</tbody>
-      </table>
-    </div>
-  </div>);
+  );
 }

--- a/utils/nflWeek.ts
+++ b/utils/nflWeek.ts
@@ -1,4 +1,5 @@
 const REGULAR_SEASON_WEEKS = 18;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 
 const toUtcDate = (year: number, monthIndex: number, day: number, hours = 0): Date => {
   const date = new Date(Date.UTC(year, monthIndex, day, hours, 0, 0, 0));
@@ -52,5 +53,16 @@ export function lastCompletedNflWeek(now: Date = new Date()): LastCompletedWeek 
   const weeksSince = Math.floor(msSinceCutoff / (7 * 24 * 60 * 60 * 1000)) + 1;
   const week = clampWeek(weeksSince);
   return { season, week };
+}
+
+export function nflWeekWindowUtc(
+  season: number,
+  week: number,
+): { startISO: string; endISO: string } {
+  const clampedWeek = clampWeek(week);
+  const cutoff = weekOneTuesdayCutoff(season);
+  const end = new Date(cutoff.getTime() + (clampedWeek - 1) * MS_PER_WEEK);
+  const start = new Date(end.getTime() - MS_PER_WEEK);
+  return { startISO: start.toISOString(), endISO: end.toISOString() };
 }
 

--- a/utils/schedules.ts
+++ b/utils/schedules.ts
@@ -1,0 +1,113 @@
+import { normalizeSchool } from "./datasources";
+
+export type CfbGame = {
+  season: number;
+  week: number;
+  seasonType: "regular" | "postseason";
+  home: string;
+  away: string;
+  kickoffISO: string | null;
+};
+
+const CFBD_API_BASE = "https://api.collegefootballdata.com";
+
+type SeasonType = "regular" | "postseason";
+
+type RawCfbGame = {
+  week?: number;
+  home_team?: string;
+  home?: string;
+  away_team?: string;
+  away?: string;
+  start_date?: string;
+  start_time?: string;
+  kickoff?: string;
+};
+
+const parseIsoCandidate = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+};
+
+const combineDateAndTime = (dateValue: unknown, timeValue: unknown): string | null => {
+  if (typeof dateValue !== "string") return null;
+  const date = dateValue.trim();
+  if (!date) return null;
+  if (typeof timeValue !== "string" || !timeValue.trim()) {
+    return parseIsoCandidate(date);
+  }
+  const candidate = `${date}T${timeValue.trim()}`;
+  return parseIsoCandidate(candidate);
+};
+
+const mapTeamGame = (season: number, seasonType: SeasonType, raw: RawCfbGame): CfbGame => {
+  const week = Number(raw.week ?? 0);
+  const home = normalizeSchool(String(raw.home_team ?? raw.home ?? ""));
+  const away = normalizeSchool(String(raw.away_team ?? raw.away ?? ""));
+  const kickoffISO =
+    parseIsoCandidate(raw.start_date)
+    || parseIsoCandidate(raw.start_time)
+    || parseIsoCandidate(raw.kickoff)
+    || combineDateAndTime(raw.start_date, raw.start_time);
+  return {
+    season,
+    week,
+    seasonType,
+    home,
+    away,
+    kickoffISO,
+  };
+};
+
+const fetchTeamGames = async (season: number, team: string, seasonType: SeasonType): Promise<CfbGame[]> => {
+  const apiKey = process.env.CFBD_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("Missing CFBD_API_KEY environment variable");
+  }
+  const params = new URLSearchParams({
+    year: String(season),
+    team,
+    seasonType,
+  });
+  const res = await fetch(`${CFBD_API_BASE}/games?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`CFBD team schedule fetch failed: ${res.status}`);
+  }
+  const payload = (await res.json()) as RawCfbGame[];
+  return payload.map((game) => mapTeamGame(season, seasonType, game));
+};
+
+export async function getCfbTeamSeasonGames(season: number, team: string): Promise<CfbGame[]> {
+  const normalizedTeam = normalizeSchool(team);
+  const seasonTypes: SeasonType[] = ["regular", "postseason"];
+  const games: CfbGame[] = [];
+  for (const seasonType of seasonTypes) {
+    try {
+      const fetched = await fetchTeamGames(season, team, seasonType);
+      for (const game of fetched) {
+        if (game.home === normalizedTeam || game.away === normalizedTeam) {
+          games.push(game);
+        }
+      }
+    } catch (error) {
+      if (seasonType === "regular") throw error;
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to load ${seasonType} games for ${team}:`, error);
+    }
+  }
+  games.sort((a, b) => {
+    if (a.week !== b.week) return a.week - b.week;
+    if (a.kickoffISO && b.kickoffISO) return a.kickoffISO.localeCompare(b.kickoffISO);
+    if (a.kickoffISO) return -1;
+    if (b.kickoffISO) return 1;
+    return 0;
+  });
+  return games;
+}


### PR DESCRIPTION
## Summary
- add an on-demand alumni matchup API that fetches the latest NFL week, joins colleges, and caches per-team rows
- pull CFBD team schedules through a new helper and expose an NFL week window utility for the response metadata
- surface a Game Results table on each school detail page that calls the API, handles pending states, and renders matchups

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d59db17c088332a4efbb5e3db4a653