### PR TITLE
Normalize CFBD schedule fetches

### DIFF
--- a/tests/schedulesFetch.test.js
+++ b/tests/schedulesFetch.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { loadTsModule } = require('./helpers/loadTsModule');
+
+test('getCfbTeamSeasonGames normalizes team before fetching schedule', async (t) => {
+  const modulePath = path.resolve(__dirname, '../utils/schedules.ts');
+  const originalFetch = global.fetch;
+  const originalApiKey = process.env.CFBD_API_KEY;
+  process.env.CFBD_API_KEY = 'test-key';
+
+  const requests = [];
+  global.fetch = async (url, options) => {
+    requests.push({ url, options });
+    const parsed = new URL(url);
+    const teamParam = parsed.searchParams.get('team');
+    const seasonType = parsed.searchParams.get('seasonType');
+
+    assert.equal(teamParam, 'Miami (FL)', 'expected normalized team in CFBD request');
+
+    const payload = [];
+    if (seasonType === 'regular') {
+      payload.push({
+        week: 1,
+        home_team: 'Miami (FL)',
+        away_team: 'Florida A&M',
+        start_date: '2024-08-24',
+      });
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    };
+  };
+
+  t.after(() => {
+    global.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      delete process.env.CFBD_API_KEY;
+    } else {
+      process.env.CFBD_API_KEY = originalApiKey;
+    }
+  });
+
+  const { getCfbTeamSeasonGames } = loadTsModule(modulePath);
+  const games = await getCfbTeamSeasonGames(2024, 'miami');
+
+  assert.equal(games.length, 1);
+  assert.equal(games[0].home, 'Miami (FL)');
+  assert.equal(games[0].away, 'Florida A&M');
+  assert.equal(games[0].seasonType, 'regular');
+
+  assert.equal(requests.length, 2);
+  for (const request of requests) {
+    const { searchParams } = new URL(request.url);
+    assert.equal(searchParams.get('team'), 'Miami (FL)');
+    assert.equal(request.options?.headers?.Authorization, 'Bearer test-key');
+  }
+});
+

--- a/utils/schedules.ts
+++ b/utils/schedules.ts
@@ -90,7 +90,7 @@ export async function getCfbTeamSeasonGames(season: number, team: string): Promi
   const games: CfbGame[] = [];
   for (const seasonType of seasonTypes) {
     try {
-      const fetched = await fetchTeamGames(season, team, seasonType);
+      const fetched = await fetchTeamGames(season, normalizedTeam, seasonType);
       for (const game of fetched) {
         if (game.home === normalizedTeam || game.away === normalizedTeam) {
           games.push(game);


### PR DESCRIPTION
## Summary
- update CFBD schedule fetches to request games with normalized school names
- add regression test to ensure normalized team names return real games

## Testing
- node --test tests/schedulesFetch.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d69ae57e0c8332b1434ff7983c0632